### PR TITLE
fix(ci): wait for demo-apps Ingress in route-readiness poll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,21 +170,27 @@ jobs:
       - name: Wait for ingress route readiness
         # K1.5 — `kubectl wait` returns once `.status.loadBalancer.ingress[0]`
         # is populated, but cloud-provider-kind's per-Service `kindccm-<hash>`
-        # Envoy sidecar takes 5–60s longer to wire the data path. The first
-        # curl after `kubectl wait` frequently returns `(56) Recv failure:
-        # Connection reset by peer` until the data plane catches up. Poll
-        # demo.localdev.me through the ingress IP until the body assertion
-        # would succeed; bail with a diagnostic dump after 60×2s.
+        # Envoy sidecar takes 5–60s longer to wire the data path. AND the
+        # demo-apps Ingress (helloweb / golang / foo) reconcile can lag the
+        # demo-localhost Ingress (demo.localdev.me) — polling only the latter
+        # misses that race and the smoke test then intermittently fails the
+        # demo-apps assertions (MetalLB E2E hit exactly this on the `c3a9315`
+        # merge run and earlier on `170c7c9`). Wait for BOTH ingresses to
+        # respond. Bail with a diagnostic dump after 60×2s.
         run: |
           INGRESS_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          probe() {
+            docker exec kind-control-plane curl -sf --max-time 3 \
+              -H "Host: $1" "http://${INGRESS_IP}/" 2>/dev/null | grep -q "$2"
+          }
           for i in $(seq 1 60); do
-            if docker exec kind-control-plane curl -sf --max-time 3 -H 'Host: demo.localdev.me' "http://${INGRESS_IP}/" 2>/dev/null | grep -q 'It works!'; then
-              echo "ingress route ready after $((i*2))s"
+            if probe demo.localdev.me 'It works!' && probe helloweb.localdev.me 'Hello, world!'; then
+              echo "ingress routes ready after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "ERROR: ingress route did not become reachable within 120s"
+          echo "ERROR: ingress routes did not become reachable within 120s"
           kubectl -n ingress-nginx get pods -o wide
           kubectl -n ingress-nginx logs deploy/ingress-nginx-controller --tail=80 || true
           docker ps --filter name=cloud-provider-kind --filter name=kindccm- --format 'table {{.Names}}\t{{.Status}}'

--- a/.github/workflows/e2e-metallb.yml
+++ b/.github/workflows/e2e-metallb.yml
@@ -99,21 +99,26 @@ jobs:
             || { echo "ERROR: demo-apps ingress did not propagate after 60s"; kubectl get ingress/demo-apps -o yaml; exit 1; }
 
       - name: Wait for ingress route readiness
-        # K1.5 — `kubectl wait` returns once `.status.loadBalancer.ingress[0]`
-        # is populated, but MetalLB's L2 announcement / iptables rules take
-        # additional time to wire the data path. Poll demo.localdev.me through
-        # the ingress IP until the body assertion would succeed; bail with a
-        # diagnostic dump after 60×2s.
+        # K1.5 — MetalLB's L2 announcement / iptables rules take time to wire
+        # the data path. AND the demo-apps Ingress (helloweb / golang / foo)
+        # reconcile can lag the demo-localhost Ingress (demo.localdev.me) —
+        # polling only the latter misses that race; the `c3a9315` merge run
+        # failed 3/4 demo-app assertions for exactly this reason. Wait for
+        # BOTH ingresses to respond. Bail with a diagnostic dump after 60×2s.
         run: |
           INGRESS_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          probe() {
+            docker exec kind-control-plane curl -sf --max-time 3 \
+              -H "Host: $1" "http://${INGRESS_IP}/" 2>/dev/null | grep -q "$2"
+          }
           for i in $(seq 1 60); do
-            if docker exec kind-control-plane curl -sf --max-time 3 -H 'Host: demo.localdev.me' "http://${INGRESS_IP}/" 2>/dev/null | grep -q 'It works!'; then
-              echo "ingress route ready after $((i*2))s"
+            if probe demo.localdev.me 'It works!' && probe helloweb.localdev.me 'Hello, world!'; then
+              echo "ingress routes ready after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "ERROR: ingress route did not become reachable within 120s"
+          echo "ERROR: ingress routes did not become reachable within 120s"
           kubectl -n ingress-nginx get pods -o wide
           kubectl -n ingress-nginx logs deploy/ingress-nginx-controller --tail=80 || true
           kubectl -n metallb-system get pods,ipaddresspool,l2advertisement -o wide || true

--- a/.github/workflows/monitoring-test.yml
+++ b/.github/workflows/monitoring-test.yml
@@ -83,17 +83,23 @@ jobs:
             || { echo "ERROR: demo-apps ingress did not propagate after 60s"; kubectl get ingress/demo-apps -o yaml; exit 1; }
 
       - name: Wait for ingress route readiness
-        # K1.5 — same poll as ci.yml.
+        # K1.5 — same dual-probe poll as ci.yml: wait for both the
+        # demo-localhost Ingress (demo.localdev.me) and the demo-apps
+        # Ingress (helloweb host) before running the smoke test.
         run: |
           INGRESS_IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          probe() {
+            docker exec kind-control-plane curl -sf --max-time 3 \
+              -H "Host: $1" "http://${INGRESS_IP}/" 2>/dev/null | grep -q "$2"
+          }
           for i in $(seq 1 60); do
-            if docker exec kind-control-plane curl -sf --max-time 3 -H 'Host: demo.localdev.me' "http://${INGRESS_IP}/" 2>/dev/null | grep -q 'It works!'; then
-              echo "ingress route ready after $((i*2))s"
+            if probe demo.localdev.me 'It works!' && probe helloweb.localdev.me 'Hello, world!'; then
+              echo "ingress routes ready after $((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "ERROR: ingress route did not become reachable within 120s"
+          echo "ERROR: ingress routes did not become reachable within 120s"
           kubectl -n ingress-nginx get pods -o wide
           docker ps --filter name=cloud-provider-kind --filter name=kindccm- --format 'table {{.Names}}\t{{.Status}}'
           exit 1


### PR DESCRIPTION
## Summary

The `Wait for ingress route readiness` step in `ci.yml`, `e2e-metallb.yml`,
and `monitoring-test.yml` polled only `demo.localdev.me` — which is served
by the **`demo-localhost`** Ingress, a *separate* object from the
**`demo-apps`** Ingress that the smoke test asserts on (`helloweb` /
`golang` / `foo`). When the `demo-apps` reconcile lagged the
`demo-localhost` reconcile, the smoke test raced it and intermittently
failed.

This bit:

- MetalLB E2E on the `c3a9315` merge run — 3/4 demo-app assertions failed
  inside a 1.4 s smoke window while `demo.localdev.me` passed.
- MetalLB E2E on an earlier scheduled run (`170c7c9`), pre-dating the
  recent project-review work.

## Fix

The readiness step now probes **both** ingresses and only proceeds when
both respond:

```bash
probe() {
  docker exec kind-control-plane curl -sf --max-time 3 \
    -H "Host: $1" "http://${INGRESS_IP}/" 2>/dev/null | grep -q "$2"
}
for i in $(seq 1 60); do
  if probe demo.localdev.me 'It works!' && probe helloweb.localdev.me 'Hello, world!'; then
    echo "ingress routes ready after $((i*2))s"
    exit 0
  fi
  sleep 2
done
```

Applied identically in all three workflows; each keeps its own
LB-specific diagnostic dump (CPK / kindccm sidecars in `ci.yml` and
`monitoring-test.yml`, MetalLB pools/L2Advertisements in
`e2e-metallb.yml`).

## Test plan
- [x] `make ci` — green (actionlint + shellcheck clean on the new `run:` blocks)
- [ ] CI on this PR
- [ ] Post-merge: MetalLB E2E + Monitoring E2E re-triggered (this PR
      touches both workflows' push paths) — they exercise the fix on
      real MetalLB and cloud-provider-kind clusters
