### PR TITLE
chore: bump puml2drawio 1.0.1 -> 1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ MERMAID_CLI_VERSION := 11.15.0
 # renovate: datasource=docker depName=plantuml/plantuml
 PLANTUML_VERSION := 1.2026.4
 # renovate: datasource=docker depName=ghcr.io/andriykalashnykov/puml2drawio
-PUML2DRAWIO_VERSION := 1.0.1
+PUML2DRAWIO_VERSION := 1.6.0
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
 KUBECTL_VERSION := v1.36.1
 # KIND_NODE_IMAGE is bumped together with kind in .mise.toml per KinD release notes.


### PR DESCRIPTION
## Summary

- Bumps `PUML2DRAWIO_VERSION` from `1.0.1` to `1.6.0` (Makefile, consumed by `make diagrams-drawio`).
- Spike against `docs/diagrams/*.puml` showed v1.0.1 silently dropped most C4 macros (c4-context emitted 6 mxCells for ~24 declared entities); v1.6.0 emits every C4 element correctly. 4-8x more cells per diagram, all matching the source.
- Output is gitignored (`docs/diagrams/drawio/` excluded — `make diagrams-drawio` is a local-editing convenience target). No committed-artifact drift.

## Test plan
- [x] `make lint` clean locally
- [x] `make diagrams-drawio` succeeds at v1.6.0; output is well-formed XML
- [ ] CI passes