### PR TITLE
chore: run kubectl-test image as non-root (USER 10001) with setcap

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,11 +8,22 @@ LABEL maintainer="Andriy Kalashnykov" description="Kubernetes testing image"
 # the kubectl packageRule groups it with the Makefile + .mise.toml + cloud-init.
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
 ARG KUBECTL_VERSION=v1.36.1
+
+# Non-root identity. Overridable for hosts whose UID/GID mapping needs it.
+ARG APP_UID=10001
+ARG APP_GID=10001
+
+# libcap supplies `setcap` so the raw-socket diagnostic tools below remain
+# usable under USER ${APP_UID} (tcpdump and nmap have no preset caps and
+# no setuid bit on alpine, so without setcap they fail "Operation not
+# permitted" non-root; /bin/ping and /usr/sbin/mtr-packet ship setuid on
+# alpine 3.23 and already work non-root).
 ARG APK_PACKAGES="bash \
                   bind-tools \
                   curl \
                   iputils \
                   iperf3 \
+                  libcap \
                   mtr \
                   netcat-openbsd \
                   nmap \
@@ -23,11 +34,18 @@ ARG APK_PACKAGES="bash \
 
 
 RUN apk --no-cache add --update $APK_PACKAGES && \
+    addgroup -g ${APP_GID} -S app && \
+    adduser -u ${APP_UID} -G app -S -h /home/app app && \
     curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" && \
     echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c && \
     chmod +x kubectl && \
     mv ./kubectl /usr/local/bin/kubectl && \
+    setcap cap_net_raw,cap_net_admin+eip /usr/bin/tcpdump && \
+    setcap cap_net_raw+eip /usr/bin/nmap && \
     rm -rf /var/cache/apk/* kubectl.sha256
+
+USER ${APP_UID}
+WORKDIR /home/app
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

- Adds non-root `app` user (uid 10001) to `images/Dockerfile`; switches runtime `USER` to it.
- Adds `setcap cap_net_raw[,cap_net_admin]+eip` to `tcpdump` and `nmap` so the raw-socket diagnostic tools stay functional under the non-root user.
- `/bin/ping` and `/usr/sbin/mtr-packet` already ship setuid on alpine 3.23, so they need no setcap.
- `libcap` added to `APK_PACKAGES` (provides `setcap` at build time).

## Why

Defensive hardening — `make image-build` was producing a root-by-default image. Non-root + minimum caps closes the most-common image-hardening finding without breaking the network-diag use case the image is built for.

## Test plan
- [x] `make lint` (hadolint) clean
- [x] `make image-test` passes (kubectl --client works under uid 10001)
- [x] Verified in built image: `id` shows uid=10001, `getcap` shows expected caps on tcpdump/nmap, ping/mtr-packet remain setuid
- [ ] CI passes