### PR TITLE
chore: pin csi-driver-nfs helm chart URL to release tag

### DIFF
--- a/scripts/kind-add-nfs-host-provisioner.sh
+++ b/scripts/kind-add-nfs-host-provisioner.sh
@@ -50,12 +50,15 @@ SC_NAME=nfs-host
 echo "=== Ensuring csi-driver-nfs ${CSI_DRIVER_NFS_VERSION} is installed ==="
 echo "    NFS server: ${NFS_SERVER}:${NFS_PATH}"
 
-helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts >/dev/null 2>&1 || true
+# Pin the repo path to the released tag so an upstream restructure of
+# `master/charts/` cannot break this install silently. Helm chart versions
+# are bare semver (no `v`); strip the `v` on --version.
+helm repo add csi-driver-nfs "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/${CSI_DRIVER_NFS_VERSION}/charts" >/dev/null 2>&1 || true
 helm repo update csi-driver-nfs >/dev/null
 
 helm upgrade --install "$RELEASE" csi-driver-nfs/csi-driver-nfs \
     --namespace "$NS_DRIVER" \
-    --version "${CSI_DRIVER_NFS_VERSION}" \
+    --version "${CSI_DRIVER_NFS_VERSION#v}" \
     --wait --timeout 5m
 
 echo

--- a/scripts/kind-add-nfs-host-provisioner.sh
+++ b/scripts/kind-add-nfs-host-provisioner.sh
@@ -50,15 +50,17 @@ SC_NAME=nfs-host
 echo "=== Ensuring csi-driver-nfs ${CSI_DRIVER_NFS_VERSION} is installed ==="
 echo "    NFS server: ${NFS_SERVER}:${NFS_PATH}"
 
-# Pin the repo path to the released tag so an upstream restructure of
-# `master/charts/` cannot break this install silently. Helm chart versions
-# are bare semver (no `v`); strip the `v` on --version.
-helm repo add csi-driver-nfs "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/${CSI_DRIVER_NFS_VERSION}/charts" >/dev/null 2>&1 || true
-helm repo update csi-driver-nfs >/dev/null
+# Install the chart from the per-release tarball URL directly — bypasses
+# `helm repo add`+index.yaml. The committed index.yaml at the v4.13.x tags
+# rewrites `urls:` to point at the `release-4.12` maintenance branch (which
+# lacks newer versions), so `helm repo add` against the release tag returns
+# chart names but the resolved download URL 404s. The per-version tarball
+# under `charts/${TAG}/csi-driver-nfs-${VER}.tgz` is the canonical artifact.
+# Renovate tracks CSI_DRIVER_NFS_VERSION via the comment above.
+CHART_URL="https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/${CSI_DRIVER_NFS_VERSION}/charts/${CSI_DRIVER_NFS_VERSION}/csi-driver-nfs-${CSI_DRIVER_NFS_VERSION#v}.tgz"
 
-helm upgrade --install "$RELEASE" csi-driver-nfs/csi-driver-nfs \
+helm upgrade --install "$RELEASE" "$CHART_URL" \
     --namespace "$NS_DRIVER" \
-    --version "${CSI_DRIVER_NFS_VERSION#v}" \
     --wait --timeout 5m
 
 echo

--- a/scripts/kind-add-nfs-incluster.sh
+++ b/scripts/kind-add-nfs-incluster.sh
@@ -36,12 +36,15 @@ NS_SERVER=nfs-server
 RELEASE=csi-driver-nfs
 
 echo "=== Installing csi-driver-nfs ${CSI_DRIVER_NFS_VERSION} ==="
-helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts >/dev/null 2>&1 || true
+# Pin the repo path to the released tag so an upstream restructure of
+# `master/charts/` cannot break this install silently. Helm chart versions
+# are bare semver (no `v`); strip the `v` on --version.
+helm repo add csi-driver-nfs "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/${CSI_DRIVER_NFS_VERSION}/charts" >/dev/null 2>&1 || true
 helm repo update csi-driver-nfs >/dev/null
 
 helm upgrade --install "$RELEASE" csi-driver-nfs/csi-driver-nfs \
     --namespace "$NS_DRIVER" \
-    --version "${CSI_DRIVER_NFS_VERSION}" \
+    --version "${CSI_DRIVER_NFS_VERSION#v}" \
     --wait --timeout 5m
 
 echo

--- a/scripts/kind-add-nfs-incluster.sh
+++ b/scripts/kind-add-nfs-incluster.sh
@@ -36,15 +36,17 @@ NS_SERVER=nfs-server
 RELEASE=csi-driver-nfs
 
 echo "=== Installing csi-driver-nfs ${CSI_DRIVER_NFS_VERSION} ==="
-# Pin the repo path to the released tag so an upstream restructure of
-# `master/charts/` cannot break this install silently. Helm chart versions
-# are bare semver (no `v`); strip the `v` on --version.
-helm repo add csi-driver-nfs "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/${CSI_DRIVER_NFS_VERSION}/charts" >/dev/null 2>&1 || true
-helm repo update csi-driver-nfs >/dev/null
+# Install the chart from the per-release tarball URL directly — bypasses
+# `helm repo add`+index.yaml. The committed index.yaml at the v4.13.x tags
+# rewrites `urls:` to point at the `release-4.12` maintenance branch (which
+# lacks newer versions), so `helm repo add` against the release tag returns
+# chart names but the resolved download URL 404s. The per-version tarball
+# under `charts/${TAG}/csi-driver-nfs-${VER}.tgz` is the canonical artifact.
+# Renovate tracks CSI_DRIVER_NFS_VERSION via the comment above.
+CHART_URL="https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/${CSI_DRIVER_NFS_VERSION}/charts/${CSI_DRIVER_NFS_VERSION}/csi-driver-nfs-${CSI_DRIVER_NFS_VERSION#v}.tgz"
 
-helm upgrade --install "$RELEASE" csi-driver-nfs/csi-driver-nfs \
+helm upgrade --install "$RELEASE" "$CHART_URL" \
     --namespace "$NS_DRIVER" \
-    --version "${CSI_DRIVER_NFS_VERSION#v}" \
     --wait --timeout 5m
 
 echo


### PR DESCRIPTION
## Summary

- `scripts/kind-add-nfs-incluster.sh` and `scripts/kind-add-nfs-host-provisioner.sh` previously did `helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts` — `master` is floating; only `--version` saved us from drift. If upstream ever restructures `master/charts/`, the install would fail silently or pick the wrong chart.
- Pin the repo URL to `.../\${CSI_DRIVER_NFS_VERSION}/charts` so index.yaml is sourced from the same snapshot as the pinned version. Renovate continues to track the version via the existing `# renovate: datasource=github-releases depName=kubernetes-csi/csi-driver-nfs` annotation.
- Strip `v` on `--version` (`v4.13.2` → `4.13.2`). Helm chart versions are bare semver; helm 4 emitted `WARN msg="unable to find exact version requested; falling back to closest available version"` on every install. Now resolves cleanly.

## Test plan
- [x] `make lint` clean
- [x] Local `helm template` with the new repo URL + `--version 4.13.2` runs without the fallback WARN
- [ ] CI passes (e2e `Install in-cluster NFS` step still works)