### PR TITLE
chore(renovate): scope workload-image groupName to per-package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,9 +78,10 @@
       "groupName": "Docker dependencies"
     },
     {
-      "description": "Keep workload image bumps in sync across k8s/*.yaml and scripts/*.sh — YAML image: field (kubernetes manager) and matching scripts' IMAGE= variable (custom.regex on shell) land in one PR so `kind load docker-image` and `kubectl apply` can't disagree on the tag.",
+      "description": "Keep workload image bumps in sync across k8s/*.yaml and scripts/*.sh — YAML image: field (kubernetes manager) and matching scripts' IMAGE= variable (custom.regex on shell) land in one PR so `kind load docker-image` and `kubectl apply` can't disagree on the tag. matchUpdateTypes scopes the rule to per-package updates only — Renovate's Pin Dependencies operation bundles many unrelated deps into one PR with no single {{depName}} for the template to resolve, which produced a literal `workload-image-depname` branch name and an `Error updating branch: update failure` in the Dependency Dashboard. Letting `pin` fall back to default grouping fixes the collapse.",
       "matchDatasources": ["docker"],
       "matchManagers": ["kubernetes", "custom.regex"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest"],
       "groupName": "workload image {{depName}}"
     },
     {


### PR DESCRIPTION
## Summary

Fixes the `WARN: Error updating branch: update failure` Repository Problem in the Renovate Dependency Dashboard and the stuck `renovate/workload-image-depname` Errored branch.

Root cause: the `workload image {{depName}}` groupName fires on every docker-datasource dep including Renovate's Pin Dependencies operation, which bundles unrelated deps into one PR with no single `{{depName}}` for the template to resolve — the literal string `workload-image-depname` was used as the branch name, failing the create.

Fix: add `matchUpdateTypes: ["major", "minor", "patch", "digest"]` so the rule only applies to per-package updates; Pin operations fall back to default grouping.

## Test plan
- [x] `make renovate-validate` clean
- [x] Local `LOG_LEVEL=debug npx renovate --platform=local` no longer shows the workload-image branch-name collapse
- [ ] Next Renovate cycle on the repo produces a clean Pin Dependencies PR and Dependency Dashboard clears the Repository Problem