### PR TITLE
chore(renovate): broaden pinDigests=false to all custom.regex docker pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,9 +78,8 @@
       "groupName": "Docker dependencies"
     },
     {
-      "description": "Disable digest pinning for Makefile-tracked docker dev tools (MERMAID_CLI_VERSION, PLANTUML_VERSION, PUML2DRAWIO_VERSION, KIND_NODE_IMAGE, ACT_UBUNTU_VERSION). The `docker:pinDigests` preset (inherited via config:best-practices) would otherwise generate a pinDigest update that collides with version bumps in `renovate/makefile-tools` and silently suppresses the bump — at-risk pattern per /renovate skill, preventive fix. Makefile-tracked deps are dev tools (PlantUML/mermaid renderers, kindest/node, catthehacker/ubuntu for act), not production runtime — version pinning alone is sufficient. Production-runtime docker pins (Dockerfile FROM, k8s/*.yaml image: fields) keep their digest pins via the same preset.",
+      "description": "Disable digest pinning for ALL custom.regex-tracked docker pins. Covers two file groups: (a) Makefile dev tools (MERMAID_CLI_VERSION, PLANTUML_VERSION, PUML2DRAWIO_VERSION, KIND_NODE_IMAGE, ACT_UBUNTU_VERSION) — preventive per /renovate skill's `docker:pinDigests × version-bump` collision class; (b) scripts/*.sh workload-image refs (hashicorp/http-echo, gcr.io/.../hello-app, ghcr.io/.../golang-web, registry, itsthenetwork/nfs-server-alpine) — the shell-script regex captures `IMAGE=foo/bar:${X_VERSION}` constructions which cannot carry an `@sha256:...` digest in the variable's value, so the Pin Dependencies operation kept failing on these (Dependency Dashboard 'Repository Problem: Error updating branch'). Production-runtime docker pins (Dockerfile FROM, k8s/*.yaml image: fields) keep their digest pins via the dockerfile + kubernetes managers respectively.",
       "matchManagers": ["custom.regex"],
-      "matchFileNames": ["Makefile"],
       "matchDatasources": ["docker"],
       "pinDigests": false
     },


### PR DESCRIPTION
## Summary

PR #64 fixed the Makefile half of the `docker:pinDigests` collision; this PR extends the fix to the shell-script half so the Dependency Dashboard's `Repository Problem: Error updating branch: update failure` clears.

After PR #64, the errored `renovate/pin-dependencies` bundle shrank but still contained 6 workload-image refs:

- `hashicorp/http-echo`, `gcr.io/.../hello-app`, `us-docker.pkg.dev/.../hello-app`, `ghcr.io/.../golang-web`, `registry`, `itsthenetwork/nfs-server-alpine`

Root cause: the `scripts/*.sh` customManager regex captures `IMAGE=foo/bar:\${X_VERSION}` constructions, which by shape can't carry an `@sha256:...` digest in the variable's value. Renovate's Pin Dependencies operation kept failing on every retry.

Fix: broaden the existing `pinDigests: false` rule by dropping `matchFileNames: ["Makefile"]` so it scopes to all custom.regex docker pins.

Production-runtime docker pins (Dockerfile FROM, k8s/*.yaml image: fields) still get their digests via the `dockerfile` + `kubernetes` managers.

## Test plan
- [x] `make renovate-validate` clean
- [x] Local renovate run produces clean per-manager stats with no `validationError`
- [ ] Next Renovate cycle clears the Repository Problem from Dependency Dashboard #31