### PR TITLE
fix(renovate): track all Makefile pins; align KIND_NODE_IMAGE to v1.36.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PUML2DRAWIO_VERSION := 1.6.0
 KUBECTL_VERSION := v1.36.1
 # KIND_NODE_IMAGE is bumped together with kind in .mise.toml per KinD release notes.
 # renovate: datasource=docker depName=kindest/node
-KIND_NODE_IMAGE := kindest/node:v1.35.0
+KIND_NODE_IMAGE := kindest/node:v1.36.1
 # renovate: datasource=github-releases depName=kubernetes-sigs/cloud-provider-kind extractVersion=^v(?<version>.*)$
 CLOUD_PROVIDER_KIND_VERSION := 0.10.0
 export CLOUD_PROVIDER_KIND_VERSION

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ First boot takes ~3–5 min (Ubuntu cloud image download, apt-get install, docke
 
 The cloud-init playbook (`vm/cloud-init.yaml`) runs once at first boot:
 
-1. Installs Docker CE, KinD v0.31.0, kubectl v1.36.1, helm v4.2.0
+1. Installs Docker CE, KinD v0.32.0, kubectl v1.36.1, helm v4.2.0
 2. Installs `nfs-kernel-server`, exports `/srv/k8s_nfs_storage`
 3. Clones this repo to `/home/ubuntu/kind-cluster`
 4. Writes `/var/lib/kind-cluster-bootstrapped` as the finished sentinel — `vm-up.sh` polls this file.

--- a/renovate.json
+++ b/renovate.json
@@ -30,10 +30,11 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update Makefile tool versions via inline renovate comments",
+      "description": "Update Makefile tool versions via inline renovate comments. Two matchStrings: (1) plain `VAR := value` pins (mermaid-cli, plantuml, puml2drawio, kubectl, cloud-provider-kind, act-ubuntu); (2) `VAR := image:tag` pins (KIND_NODE_IMAGE) where only the trailing tag is the version. The var-name class is [A-Z0-9_]+ so digit-containing names like PUML2DRAWIO_VERSION match (a prior [A-Z_]+ stopped at the digit and silently dropped it). extractVersion/registryUrl/versioning are all optional so cloud-provider-kind's `extractVersion=^v...` and act-ubuntu's `versioning=loose` are honored (a prior matchString lacked extractVersion and silently dropped CLOUD_PROVIDER_KIND_VERSION). matchString (1) excludes the image:tag shape by anchoring currentValue to end-of-line; matchString (2) captures the tag after the last colon (a prior single matchString captured the whole `kindest/node:v1.35.0` ref as currentValue, which the docker datasource cannot resolve to a version).",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>[A-Za-z0-9_./:-]+)( versioning=(?<versioning>\\S+))?\\s*\\n[A-Z_]+\\s*:=\\s*(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>[A-Za-z0-9_./:-]+)( extractVersion=(?<extractVersion>\\S+))?( registryUrl=(?<registryUrl>\\S+))?( versioning=(?<versioning>\\S+))?\\s*\\n[A-Z0-9_]+\\s*:=\\s*(?<currentValue>[^:\\s]+)\\n",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>[A-Za-z0-9_./:-]+)( extractVersion=(?<extractVersion>\\S+))?( registryUrl=(?<registryUrl>\\S+))?( versioning=(?<versioning>\\S+))?\\s*\\n[A-Z0-9_]+\\s*:=\\s*[^\\s:]+:(?<currentValue>\\S+)"
       ]
     },
     {


### PR DESCRIPTION
## Summary

`/upgrade-analysis` found every version pin at its latest release — but uncovered **silent blind spots in Renovate's own Makefile custom-regex manager**. 3 of 7 inline-`# renovate:`-commented pins were never tracked, so they would freeze without warning (they happen to be current today). Proven via `renovate --platform=local` extract (0 `replaceString` hits each → now 1 each, correct `currentValue`).

### Root causes (all real, no workarounds)
| Pin | Bug | Fix |
|-----|-----|-----|
| `PUML2DRAWIO_VERSION` | var-name class `[A-Z_]+` stopped at the digit `2` | widen to `[A-Z0-9_]+` |
| `CLOUD_PROVIDER_KIND_VERSION` | matchString had no `extractVersion=` branch; the comment's `extractVersion=^v…` broke the match | add optional `extractVersion`/`registryUrl` groups |
| `KIND_NODE_IMAGE` | `currentValue` captured the whole ref `kindest/node:v1.35.0` (docker datasource can't resolve it) | dedicated `VAR := image:tag` matchString capturing only the tag |

The single matchString is split into two (plain `VAR := value` + `VAR := image:tag`).

### Also
- **Bump `KIND_NODE_IMAGE` v1.35.0 → v1.36.1** — v1.35.0 is **not in kind 0.32.0's prebuilt catalog** (which ships v1.33.12/v1.34.8/v1.35.5/v1.36.1) and lagged the `kubectl 1.36.1` pin. v1.36.1 aligns both and is in the catalog. Now tracked, it joins the existing `kind` group packageRule.
- **README fix** — cloud-init installs KinD **v0.32.0** (matches `vm/cloud-init.yaml`), not the stale "v0.31.0".

### Verification
- `renovate --platform=local` extract: **all 7** Makefile pins extract exactly once with correct `currentValue` (`puml2drawio=1.6.0`, `cloud-provider-kind=0.10.0`, `kindest/node=v1.36.1`); no duplicate matches.
- `make renovate-validate`: config valid.
- `make lint`: clean (shellcheck + actionlint + hadolint).
- `KIND_NODE_IMAGE` cluster-recreate is exercised by this PR's `e2e` job (Docker-in-Docker can't run under local `act`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)