### PR TITLE
feat(gateway): opt-in Traefik & Istio Gateway API + comparison doc

### DIFF
--- a/.github/workflows/gateway-test.yml
+++ b/.github/workflows/gateway-test.yml
@@ -1,0 +1,84 @@
+name: Gateway API E2E
+
+on:
+  schedule:
+    - cron: '0 7 * * 0'  # Sunday 07:00 UTC (after registry at 06:00)
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/kind-add-gateway-api-crds.sh'
+      - 'scripts/kind-add-gateway-traefik.sh'
+      - 'scripts/kind-add-gateway-istio.sh'
+      - 'scripts/kind-add-traefik.sh'
+      - 'k8s/gateway/**'
+      # Shared smoke chain: the TEST_GATEWAY_API assertions live in e2e-smoke.sh,
+      # which ci.yml never runs with TEST_GATEWAY_API=yes — so a regression there
+      # is only caught here.
+      - 'scripts/e2e-smoke.sh'
+      - 'scripts/lib.sh'
+      - '.github/workflows/gateway-test.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gateway-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gateway-e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: Install dependencies
+        run: make deps
+
+      # Full default stack (cluster + cloud-provider-kind + Traefik + Headlamp +
+      # demo apps + ingress). Gateway API is layered on top via the opt-in targets.
+      - name: Install stack
+        run: make install-all
+
+      - name: Wait for ingress route readiness
+        # K1.5 — an assigned LB IP is not the same as a routable one; poll the
+        # demo routes through the control-plane node before layering gateways on.
+        run: |
+          INGRESS_IP=$(kubectl get svc -n traefik traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          probe() {
+            docker exec kind-control-plane curl -sf --max-time 3 \
+              -H "Host: $1" "http://${INGRESS_IP}/" 2>/dev/null | grep -q "$2"
+          }
+          for i in $(seq 1 60); do
+            if probe helloweb.localdev.me 'Hello, world!'; then
+              echo "ingress routes ready after $((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: ingress routes did not become reachable within 120s"
+          kubectl -n traefik get pods -o wide
+          exit 1
+
+      - name: Enable Traefik Gateway API
+        run: make gateway-traefik
+
+      - name: Install Istio Gateway API controller
+        run: make gateway-istio
+
+      # Asserts both Gateway API controllers (Traefik provider + Istio) front the
+      # same demo backends, on top of the standard smoke checks. Quoted so YAML
+      # keeps the literal string "yes" the smoke script compares to.
+      - name: Smoke test
+        env:
+          TEST_GATEWAY_API: "yes"
+        run: make e2e-smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ scripts/              # Bash scripts for cluster lifecycle and app deployment
                       #   (lib.sh = sourceable helpers; kind-add-* installers;
                       #    migrate-from-metallb.sh; e2e-*.sh smoke tests)
 tests/                # bats unit tests for scripts/lib.sh (make test)
-k8s/                  # Kubernetes manifests (kind config, Headlamp, NFS, etc.)
+k8s/                  # Kubernetes manifests (kind config, Headlamp, NFS, gateway/, etc.)
 images/               # Dockerfiles (kubectl-test image)
 docs/diagrams/        # PlantUML C4 sources (.puml) + rendered PNGs (out/) + .drawio exports (drawio/)
 vm/                   # Multipass cloud-init playbook
@@ -68,6 +68,11 @@ make vulncheck                         # Alias for trivy-fs (portfolio-standard 
 # Local registry cluster (separate from install-all)
 make registry                          # Create a KinD cluster wired to a local registry (localhost:5001)
 make registry-test                     # Push hello-app:2.0 to the local registry and deploy it (run after 'make registry')
+
+# Gateway API (opt-in, alongside classic Ingress — see docs/gateway-api-ingress.md)
+make gateway-traefik                   # Enable Traefik's Gateway API provider + demo HTTPRoutes (*.gw.localdev.me)
+make gateway-istio                     # Install Istio as a 2nd Gateway API controller (own LB IP, same apps)
+TEST_GATEWAY_API=yes make e2e-smoke    # Smoke-assert both Gateway API controllers (after the two targets above)
 ```
 
 `make ci-run` only iterates `static-check` + `docker` jobs under `act`. The `e2e` and `e2e-metallb` jobs are skipped because KinD's Docker-in-Docker requirement is unstable under `act push`. Push to a feature branch and watch the real workflow when changing anything in the e2e path (deploy scripts, ingress wiring, K8s manifests).
@@ -78,6 +83,7 @@ make registry-test                     # Push hello-app:2.0 to the local registr
 - **e2e-metallb.yml** — weekly cron (Sunday 04:00 UTC) + `workflow_dispatch` + push on its MetalLB/migration scripts and the shared smoke chain (`scripts/kind-add-metallb.sh`, `scripts/migrate-from-metallb.sh`, `scripts/e2e-migrate-smoke.sh`, `scripts/kind-add-cloud-provider-kind.sh`, `scripts/e2e-smoke.sh`, `scripts/lib.sh`, the workflow file) (positive-include `paths:` filter is intentional — runs when its own or the shared smoke-chain code changes; the shared scripts are included so a fix that only breaks the MetalLB path, which `ci.yml`'s cloud-provider-kind `e2e` job doesn't exercise, isn't missed until the weekly cron). Mirrors the `e2e` job but installs **MetalLB** instead of cloud-provider-kind; same K1.5 route-readiness poll before `LB=metallb make e2e-smoke`. Final step runs `scripts/e2e-migrate-smoke.sh` to exercise the **MetalLB → cloud-provider-kind migration** path so regressions in `migrate-from-metallb.sh` surface here.
 - **monitoring-test.yml** — weekly cron (Sunday 05:00 UTC) + `workflow_dispatch` + push on `scripts/kind-add-kube-prometheus-stack.sh` plus the shared smoke chain (`scripts/e2e-smoke.sh`, `scripts/lib.sh`, the workflow file — the `TEST_MONITORING` assertions live in `e2e-smoke.sh`, which `ci.yml` never runs with `TEST_MONITORING=yes`). Brings up the full stack via `make install-all` (cloud-provider-kind), installs `kube-prometheus-stack`, then runs `TEST_MONITORING=yes make e2e-smoke` to assert Grafana gets a LoadBalancer IP and the admin secret is mintable. Off the default install-all path — kept on its own cron to keep PR feedback fast.
 - **registry-test.yml** — weekly cron (Sunday 06:00 UTC) + `workflow_dispatch` + push on registry-related files (`scripts/kind-with-registry.sh`, `scripts/test-registry.sh`, `scripts/lib.sh`, `k8s/helloweb-deployment-local.yaml`, the workflow file). Exercises the alternative `make registry` cluster (containerd-mirrored local registry at `localhost:5001`) via `make registry-test` (pull → retag → push → deploy → curl). Distinct from the install-all flow; separate workflow rather than another job.
+- **gateway-test.yml** — weekly cron (Sunday 07:00 UTC) + `workflow_dispatch` + push on the gateway scripts/manifests + the shared smoke chain (`scripts/kind-add-gateway-*.sh`, `k8s/gateway/**`, `scripts/kind-add-traefik.sh`, `scripts/e2e-smoke.sh`, `scripts/lib.sh`, the workflow file). Brings up `make install-all`, then `make gateway-traefik` (Traefik's Gateway API provider) + `make gateway-istio` (Istio as a 2nd Gateway API controller), then `TEST_GATEWAY_API=yes make e2e-smoke` to assert both controllers front the same demo apps. Off the default install-all path — Gateway API is opt-in (see `docs/gateway-api-ingress.md`).
 - **cleanup-runs.yml** — weekly cron (Sunday midnight). Two jobs: `cleanup-runs` (prunes old runs, keeps latest 5) and `cleanup-caches` (deletes caches from closed PR branches).
 
 ### Paths that CI does NOT exercise

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,18 @@ headlamp-token: deps
 ingress-traefik: deps
 	@./scripts/kind-add-traefik.sh
 
+#gateway-api-crds: @ Install Kubernetes Gateway API CRDs (standard channel, pinned)
+gateway-api-crds: deps
+	@./scripts/kind-add-gateway-api-crds.sh
+
+#gateway-traefik: @ Opt-in: enable Traefik's Gateway API provider + demo HTTPRoutes (see docs/gateway-api-ingress.md)
+gateway-traefik: deps
+	@./scripts/kind-add-gateway-traefik.sh
+
+#gateway-istio: @ Opt-in: install Istio as a 2nd Gateway API controller routing to the same apps (see docs/gateway-api-ingress.md)
+gateway-istio: deps
+	@./scripts/kind-add-gateway-istio.sh
+
 #lb-metallb: @ Install MetalLB load balancer (alternative to 'make lb-cpk'; use LB=metallb with install-all)
 lb-metallb: deps
 	@./scripts/kind-add-metallb.sh
@@ -385,6 +397,7 @@ clean:
 	install-all install-all-no-demo-workloads kind-up kind-down \
 	lb-cpk lb-metallb kind-create create-cluster export-cert \
 	headlamp-install headlamp-forward headlamp-token ingress-traefik \
+	gateway-api-crds gateway-traefik gateway-istio \
 	metrics-server kube-prometheus-stack \
 	nfs-incluster nfs-host-setup nfs-host-provisioner \
 	deploy-app-ingress-localhost deploy-app-helloweb \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ make lb-metallb                # already-running cluster, no LB yet — install 
 
 Switching providers on a live cluster requires tearing down the first one — each script hard-refuses if the other is present. Run `make kind-down && LB=<provider> make kind-up` for a clean reset.
 
+## Ingress vs Gateway API
+
+The default routing path is **classic Ingress** (`networking.k8s.io/v1`, `ingressClassName: traefik`) — the simplest thing that works. The Kubernetes **[Gateway API](https://gateway-api.sigs.k8s.io/)** is its GA successor (the Ingress API is frozen; ingress-nginx is retiring — the reason this project moved to Traefik). Both **Traefik** and **Istio** are conformant Gateway API controllers and can be enabled here opt-in, routing the **same** demo apps:
+
+```bash
+make gateway-traefik   # enable Traefik's Gateway API provider (same pod also keeps classic Ingress)
+make gateway-istio     # add Istio as a 2nd Gateway API controller, its own LB IP, same backends
+```
+
+They coexist because each GatewayClass has a distinct `controllerName` and cloud-provider-kind gives each gateway its own LoadBalancer IP. **Antrea is *not* in this comparison** — it's a CNI, not a Gateway API controller (its "gateway" is the `antrea-gw0` dataplane interface); the real CNI-integrated gateways are **Cilium** / **Calico**.
+
+📖 **Full comparison (Traefik vs Istio vs Cilium/Calico), coexistence mechanics, and "is it advisable to run all of them?" — see [docs/gateway-api-ingress.md](docs/gateway-api-ingress.md).**
+
 ## Headlamp install
 
 Pinned to Helm chart [`headlamp`](https://github.com/kubernetes-sigs/headlamp) **0.42.0**. Headlamp is the SIG-UI-endorsed successor to the [archived](https://github.com/kubernetes/dashboard) kubernetes/dashboard project — a single Pod fronted by a ClusterIP Service on port 80 (HTTP), with token-based login.

--- a/docs/gateway-api-ingress.md
+++ b/docs/gateway-api-ingress.md
@@ -1,0 +1,303 @@
+# Gateway API & ingress controllers in this cluster
+
+> How `kind-cluster` exposes HTTP services, why the Kubernetes **Gateway API** is
+> the strategic successor to classic **Ingress**, and a fact-checked comparison of
+> three Gateway API implementations — **Traefik**, **Istio**, and a
+> CNI-integrated option (**Cilium** / **Calico**) — including how to run more than
+> one of them in the same cluster.
+>
+> Every version, conformance status, and behaviour below is cited to a primary
+> source (see [References](#references)). Verified 2026-06-06 against Gateway API
+> **v1.5.1**, Traefik chart **40.2.0** (appVersion **v3.7.1**), Istio **1.30.1**,
+> Cilium **v1.19.4**, Calico **v3.32.0**.
+
+## TL;DR
+
+- The project's **default** path is still **classic Ingress** (`networking.k8s.io/v1`,
+  `ingressClassName: traefik`) — see [`k8s/demo-apps-ingress.yaml`](../k8s/demo-apps-ingress.yaml).
+  It is the simplest thing that works and stays the zero-config default.
+- The **Gateway API** is the future: the Ingress API is feature-frozen, and the
+  reference `ingress-nginx` controller is **retiring** (best-effort maintenance
+  ends March 2026) — which is why this project already moved to **Traefik**.
+  Gateway API is **GA** (v1.0 in Oct 2023; current **v1.5.1**).
+- Traefik v3 and Istio are both **conformant Gateway API controllers**. You can
+  enable them here opt-in:
+  - `make gateway-traefik` — turns on Traefik's Gateway API provider and routes
+    the **same** demo apps through a `Gateway` + `HTTPRoute`s (no extra workload —
+    same Traefik pod also keeps serving classic Ingress).
+  - `make gateway-istio` — installs Istio (minimal) as a **second** Gateway API
+    controller that coexists with Traefik and fronts the **same** demo apps via
+    its own LoadBalancer IP.
+- **Antrea is not in this comparison.** Antrea is a **CNI**, not a Gateway API
+  controller — its "gateway" (`antrea-gw0`) is an Open vSwitch dataplane interface,
+  unrelated to `gateway.networking.k8s.io`. If you want a **CNI-integrated**
+  gateway, the real options are **Cilium** or **Calico** (both conformant) — see
+  [§ CNI-integrated gateways](#cni-integrated-gateways-cilium--calico).
+
+---
+
+## Ingress vs Gateway API
+
+Classic **Ingress** (`networking.k8s.io/v1`) is a single, controller-specific
+resource: one object holds host/path rules, and everything beyond plain HTTP
+host/path routing (TLS options, header rewrites, traffic splitting, gRPC, TCP)
+lives in **controller-specific annotations**. That annotation sprawl, plus a lack
+of role separation, is why the Ingress API was frozen and the community built a
+replacement.
+
+The **Gateway API** (`gateway.networking.k8s.io`) is a role-oriented, typed
+replacement, GA since v1.0:
+
+| Resource | Owned by | Purpose |
+|----------|----------|---------|
+| **GatewayClass** | infrastructure provider | Names a controller via `controllerName` (like a `StorageClass` for gateways) |
+| **Gateway** | cluster operator | A concrete data-plane listener (ports, protocols, TLS) bound to one GatewayClass |
+| **HTTPRoute** / GRPCRoute / TCPRoute / TLSRoute | app developer | Routing rules: `parentRefs` (which Gateways) + `backendRefs` (which Services) |
+
+Two properties matter for everything below:
+
+1. **`GatewayClass.spec.controllerName` selects the controller.** Each controller
+   *"MUST watch all GatewayClasses, and reconcile GatewayClasses that have a
+   matching controllerName"* — and ignores the rest. This is what lets multiple
+   controllers coexist (see [§ Running more than one](#running-more-than-one-controller)).
+2. **An `HTTPRoute` references a Gateway (`parentRefs`) and Services
+   (`backendRefs`) independently.** The same backend Service can be fronted by
+   many routes under different Gateways — which is how two controllers route to
+   the *same* app.
+
+**Channels.** Gateway API ships a **standard** channel (GA: GatewayClass,
+Gateway, HTTPRoute, GRPCRoute, ReferenceGrant, BackendTLSPolicy) and an
+**experimental** channel (TCPRoute, TLSRoute, UDPRoute, …). Install one or the
+other CRD set:
+
+```bash
+# standard (GA) channel
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+# experimental channel (adds TCPRoute/TLSRoute/UDPRoute)
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+```
+
+> The CRDs are **not** bundled by Traefik's or Istio's charts — they must be
+> applied first. The project's `make gateway-*` targets do this for you (pinned,
+> Renovate-tracked).
+
+---
+
+## The implementations
+
+All three rows below are **conformant** Gateway API controllers on the official
+[implementations registry](https://gateway-api.sigs.k8s.io/implementations/)
+(checked 2026-06): Traefik Proxy (v1.5.1), Istio (v1.4), Cilium (v1.5.1).
+
+| | **Traefik** (this project's default proxy) | **Istio** | **Cilium / Calico** (CNI-integrated) |
+|---|---|---|---|
+| **What it is** | Standalone L7 reverse proxy / ingress controller | Service mesh + ingress (Envoy data plane) | A **CNI** that *also* implements Gateway API |
+| **`controllerName`** | `traefik.io/gateway-controller` | `istio.io/gateway-controller` | `cilium` (GatewayClass) / Calico via Tigera operator |
+| **GatewayClass name** | `traefik` (chart can auto-create) | `istio` (built-in; also `istio-remote`, `istio-waypoint`, `istio-east-west`) | `cilium` / a default class from the operator |
+| **Deployment model** | In-process provider in the **existing single Traefik pod** — no extra workload | `istiod` control plane **+ one Envoy Deployment+Service auto-provisioned per `Gateway`** (named `<gateway>-<class>`) | Built into the CNI agent/operator (Cilium: built-in Envoy; Calico: Envoy Gateway) |
+| **Footprint** | None beyond Traefik (already running) | Heaviest: `istiod` + per-gateway Envoy (sidecar Envoy ≈ 0.2 vCPU / 60 MB at 1k req/s; `istiod` scales with config — Istio docs give no fixed number) | CNI-level; replaces kindnet |
+| **Channels** | HTTPRoute, GRPCRoute, BackendTLSPolicy (standard); TCPRoute + **TLSRoute via `experimentalChannel`** | HTTPRoute (standard); experimental routes supported | varies |
+| **Install onto a running kind cluster?** | ✅ yes (already installed) | ✅ yes (over the existing CNI — Istio is **not** a CNI) | ❌ no — a CNI is chosen at **cluster creation** (`disableDefaultCNI`), i.e. a cluster recreate |
+| **Best for** | Lightweight north-south ingress; the default here | North-south ingress **and** east-west mesh (GAMMA); advanced traffic management | One dataplane for pod networking **and** L7 gateway (eBPF / Envoy) |
+
+### Traefik (Gateway API mode)
+
+Traefik v3 has shipped a production-ready Gateway API provider since v3.1 and is
+conformant at Gateway API **v1.5.1**. In this project it is **already running**
+as a classic Ingress controller; the Gateway API provider is a second,
+independent in-process provider — enabling it does **not** disable Ingress, and
+adds **no new pod**. Enable in the Helm chart with:
+
+```
+--set providers.kubernetesGateway.enabled=true
+# optionally: --set providers.kubernetesGateway.experimentalChannel=true   # TCPRoute/TLSRoute
+```
+
+The chart can also auto-create a default `traefik` GatewayClass and a default
+`Gateway` (`gatewayClass.enabled` / `gateway.enabled`). `make gateway-traefik`
+enables the provider and applies the demo `Gateway` + `HTTPRoute`s.
+
+> ⚠️ **Doc-vs-spec conflict we verified:** Traefik's prose docs list `TLSRoute`
+> under the *standard* channel, but the Gateway API project (and Traefik's own
+> Helm chart comment) place `TLSRoute` in the **experimental** channel. Treat
+> `TLSRoute` as experimental — it needs `experimental-install.yaml` CRDs **and**
+> `experimentalChannel=true`.
+
+### Istio (Gateway API mode)
+
+Istio is a conformant Gateway API controller (`istio.io/gateway-controller`,
+GatewayClass `istio`). Key facts for a kind lab:
+
+- **It is not a CNI** — *"ambient mode is not a CNI itself — it runs over existing
+  CNIs."* Istio installs onto the running kindnet cluster fine.
+- For **north-south ingress only**, you do **not** need to mesh the app pods (no
+  sidecar injection, no ambient enrollment). Applying a `Gateway` with
+  `gatewayClassName: istio` **auto-provisions** an Envoy `Deployment` + `Service`
+  named `<gateway>-istio`; that Service is `LoadBalancer`, so cloud-provider-kind
+  gives it its own IP.
+- **CRDs must be installed first, and version-compatible** — Istio ≤ 1.29 +
+  Gateway API v1.5 CRDs makes `istiod` crash-loop (analyzer check `IST0176`).
+  This project pins Istio **1.30.1**, which supports v1.5.x CRDs.
+- **GAMMA** (Gateway API for Mesh) extends the same API to **east-west** traffic
+  by setting an HTTPRoute's `parentRef` to a **Service** instead of a Gateway —
+  out of scope here (we only wire north-south ingress), but it's why Istio is
+  more than "another ingress."
+
+`make gateway-istio` installs the Gateway API CRDs + Istio (minimal, via the
+official Helm charts — `base` + `istiod`, no app meshing), then applies an Istio
+`Gateway` + `HTTPRoute`s for the same demo apps.
+
+### CNI-integrated gateways (Cilium / Calico)
+
+If the interest is a **single dataplane that does both pod networking and L7
+gateway**, the real options are **Cilium** and **Calico** — both on the Gateway
+API conformance list:
+
+- **Cilium** — eBPF CNI with built-in Gateway API (GatewayClass `cilium`), served
+  by an embedded **Envoy**; requires kube-proxy replacement and an LB/L2 path.
+- **Calico** — its **Calico Ingress Gateway** is a hardened distribution of the
+  **Envoy Gateway** project, provisioned by the Tigera operator from a
+  `GatewayAPI` CR.
+
+**These cannot be "added" to the running cluster.** A cluster has exactly one
+CNI, and kind installs `kindnetd` by default; switching CNIs is a
+**cluster-creation-time** decision. To try Cilium here you recreate the cluster
+with the default CNI disabled:
+
+```yaml
+# kind config — disable kindnet so a real CNI can own pod networking
+networking:
+  disableDefaultCNI: true
+  podSubnet: "10.244.0.0/16"
+```
+
+```bash
+kind create cluster --config kind-cilium.yaml
+cilium install --version 1.19.4 --set kubeProxyReplacement=true \
+  --set gatewayAPI.enabled=true        # requires Gateway API CRDs pre-applied
+```
+
+This is a different (heavier) experiment than the Traefik-vs-Istio comparison,
+which is why this repo documents it rather than wiring it into `install-all`. The
+kind docs note `disableDefaultCNI` is *"a power user feature with limited
+support, but many common CNI manifests are known to work, e.g. Calico."*
+
+### Why not Antrea?
+
+A common confusion worth stating plainly: **Antrea is a CNI, not a Gateway API
+controller.** It is **not** on the Gateway API implementations list; the
+`antrea-io/antrea` repo has no `sigs.k8s.io/gateway-api` dependency and no
+`GatewayClass`/`HTTPRoute` controller. The thing called the **"Antrea gateway"**
+is `antrea-gw0` — *"an internal port … to be the gateway of the Node's subnet"* —
+an **Open vSwitch dataplane interface** for pod/node traffic, entirely unrelated
+to `gateway.networking.k8s.io`. Antrea's L7 features (L7 NetworkPolicy — which is
+**Suricata**-based, not Envoy; AntreaProxy; Egress) are east-west CNI features,
+not a north-south HTTP gateway. If you saw "Antrea gateway" and expected the
+Kubernetes Gateway API, that's the lexical trap. For a **CNI-integrated gateway**
+use Cilium or Calico; for a fair **CNI/NetworkPolicy** comparison, Antrea belongs
+next to Cilium/Calico/kindnet — a different axis than this document.
+
+---
+
+## Running more than one controller
+
+> *Can Traefik + Istio coexist and route to the **same** apps? Yes. Is it
+> advisable? For a comparison lab, yes — with the caveats below.*
+
+**1. No API-level conflict.** Each controller reconciles only Gateways whose
+GatewayClass `controllerName` matches its own. `traefik.io/gateway-controller`
+and `istio.io/gateway-controller` are distinct, so the `traefik` and `istio`
+GatewayClasses coexist and each controller ignores the other's Gateways.
+
+**2. Same app, two front doors.** An `HTTPRoute` names its Gateway in
+`parentRefs` and its Services in `backendRefs`; nothing ties a Service to one
+route. So `demo-route-traefik` (→ Traefik Gateway) and `demo-route-istio`
+(→ Istio Gateway) can both carry `backendRefs: helloweb` — both gateways front
+the identical pods.
+
+**3. The only real contention is the entry-point address:**
+
+- **hostPort 80/443 is single-binding.** Traefik already occupies the
+  control-plane node's host ports 80/443 (via `kind-config.yaml`
+  `extraPortMappings`). A second controller **cannot** also bind them.
+- **cloud-provider-kind gives each `LoadBalancer` Service its own IP** from the
+  kind docker bridge (one `kindccm-…` Envoy container per Service). So Istio's
+  auto-provisioned gateway Service gets a **distinct** IP.
+
+So you reach **Traefik** at `http://localhost/` (hostPort) and **Istio** at its
+own `http://<istio-LB-IP>/` — same backends, different doors. No collision.
+
+```
+                         ┌─────────────────────── same backend Services ───────────────────────┐
+                         │            helloweb         golang-web         foo-service           │
+                         └───────▲───────────────────────▲──────────────────────▲──────────────┘
+        HTTPRoute(parent=traefik)│                        │ HTTPRoute(parent=istio)
+                ┌────────────────┴───────┐        ┌───────┴──────────────────┐
+   host :80 ───▶│ Traefik  (class traefik)│        │ Istio gw (class istio)   │◀── LB IP (cloud-provider-kind)
+   (hostPort)   │ controllerName:          │        │ controllerName:          │
+                │ traefik.io/gw-controller │        │ istio.io/gw-controller   │
+                └──────────────────────────┘        └──────────────────────────┘
+```
+
+### Is it advisable to install all of them?
+
+- **Traefik + Istio (Gateway API):** ✅ fine for a comparison lab — distinct
+  GatewayClass, distinct entry IP, same backends. Istio adds real weight
+  (`istiod` + a per-gateway Envoy), so it's opt-in, not part of `install-all`.
+- **A third "Antrea gateway":** ❌ not a thing — Antrea is a CNI (see above).
+- **Cilium/Calico (CNI gateway):** ⚠️ a **separate cluster** — a CNI is chosen at
+  creation time and is mutually exclusive with kindnet (and with each other). You
+  don't run it *alongside*; you recreate the cluster with it.
+
+---
+
+## How this project wires it
+
+| Target | What it does | Reach it at |
+|--------|--------------|-------------|
+| `make ingress-traefik` | **Default.** Traefik as a classic Ingress controller (`ingressClassName: traefik`), hostPort 80/443 | `http://<app>.localdev.me/` via `localhost` |
+| `make gateway-traefik` | Opt-in. Installs Gateway API CRDs (pinned), enables Traefik's Gateway API provider, applies a `Gateway` + `HTTPRoute`s for the demo apps | same Traefik entry (hostPort), now also via Gateway API |
+| `make gateway-istio` | Opt-in. Installs Gateway API CRDs + Istio (minimal) + an Istio `Gateway` + `HTTPRoute`s for the **same** demo apps | `http://<istio-gateway-LB-IP>/` |
+
+Both `gateway-*` targets are idempotent on the shared Gateway API CRDs
+(install-if-absent), require **cloud-provider-kind** to be running (for LB IPs),
+and route to the **existing** demo Services — so you can enable either or both on
+a cluster brought up with `make install-all` and compare them side by side.
+Smoke coverage for the Gateway API paths is gated behind `TEST_GATEWAY_API=yes`
+(see [`scripts/e2e-smoke.sh`](../scripts/e2e-smoke.sh)).
+
+---
+
+## References
+
+Gateway API
+- Implementations registry — <https://gateway-api.sigs.k8s.io/implementations/>
+- GatewayClass / HTTPRoute references — <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/> · <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>
+- Implementer's Guide (controllerName reconcile rule) — <https://gateway-api.sigs.k8s.io/guides/implementers/>
+- Kubernetes concept — <https://kubernetes.io/docs/concepts/services-networking/gateway/>
+- Releases (v1.5.1) — <https://github.com/kubernetes-sigs/gateway-api/releases>
+
+Traefik
+- Gateway API routing reference — <https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/gateway-api/>
+- Enable the provider / install CRDs — <https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-gateway/>
+- Helm chart values — <https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml>
+
+Istio
+- Kubernetes Gateway API task — <https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/>
+- Getting started with Gateway API (controllerName) — <https://istio.io/latest/blog/2022/getting-started-gtwapi/>
+- GAMMA / mesh — <https://gateway-api.sigs.k8s.io/mesh/> · <https://istio.io/latest/blog/2024/gateway-mesh-ga/>
+- Performance & scalability — <https://istio.io/latest/docs/ops/deployment/performance-and-scalability/>
+
+CNI-integrated gateways
+- Cilium Gateway API — <https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/>
+- Calico Gateway API — <https://docs.tigera.io/calico/latest/networking/gateway-api>
+
+Antrea (why it's not a Gateway API controller)
+- Architecture / the `antrea-gw0` gateway port — <https://antrea.io/docs/main/docs/design/architecture/>
+- L7 NetworkPolicy (Suricata-based) — <https://antrea.io/docs/main/docs/antrea-l7-network-policy/>
+- Antrea on kind (CNI swap) — <https://antrea.io/docs/main/docs/kind/>
+
+kind / LoadBalancer
+- LoadBalancer (cloud-provider-kind) — <https://kind.sigs.k8s.io/docs/user/loadbalancer/>
+- Configuration (`disableDefaultCNI`, `extraPortMappings`) — <https://kind.sigs.k8s.io/docs/user/configuration/>
+- cloud-provider-kind — <https://github.com/kubernetes-sigs/cloud-provider-kind>

--- a/k8s/gateway/istio-gateway.yaml
+++ b/k8s/gateway/istio-gateway.yaml
@@ -1,0 +1,71 @@
+# Istio Gateway API demo — a Gateway bound to Istio's built-in `istio`
+# GatewayClass (controllerName istio.io/gateway-controller). Applying this Gateway
+# auto-provisions an Envoy Deployment+Service named "demo-istio" (<gateway>-<class>)
+# in the default namespace; that Service is type LoadBalancer, so cloud-provider-kind
+# hands it its OWN external IP — a distinct front door from Traefik's hostPort 80.
+#
+# The HTTPRoutes front the SAME backend Services as the classic Ingress and the
+# Traefik Gateway, on the original *.localdev.me hostnames (no collision — Istio
+# answers on a different IP). This is the "same app, two front doors" demo.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: demo
+  namespace: default
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: istio-helloweb
+  namespace: default
+spec:
+  parentRefs:
+    - name: demo
+  hostnames: ["helloweb.localdev.me"]
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: helloweb
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: istio-golang
+  namespace: default
+spec:
+  parentRefs:
+    - name: demo
+  hostnames: ["golang.localdev.me"]
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: golang-hello-world-web-service
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: istio-foo
+  namespace: default
+spec:
+  parentRefs:
+    - name: demo
+  hostnames: ["foo.localdev.me"]
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: foo-service
+          port: 5678

--- a/k8s/gateway/traefik-gateway.yaml
+++ b/k8s/gateway/traefik-gateway.yaml
@@ -1,0 +1,70 @@
+# Traefik Gateway API demo — a Gateway bound to the chart-created `traefik`
+# GatewayClass (controllerName traefik.io/gateway-controller), plus HTTPRoutes
+# that front the SAME demo Services as the classic Ingress, on *.gw.localdev.me
+# hostnames (so they don't collide with the classic Ingress *.localdev.me on
+# Traefik's shared web entrypoint).
+#
+# Listener port 8000 is Traefik's internal `web` entrypoint (exposed on hostPort
+# 80 by kind-add-traefik.sh), so curl http://localhost/ reaches these routes.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: traefik-gateway
+  namespace: default
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: web
+      protocol: HTTP
+      port: 8000
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gw-helloweb
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+  hostnames: ["helloweb.gw.localdev.me"]
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: helloweb
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gw-golang
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+  hostnames: ["golang.gw.localdev.me"]
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: golang-hello-world-web-service
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gw-foo
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+  hostnames: ["foo.gw.localdev.me"]
+  rules:
+    - matches:
+        - path: { type: PathPrefix, value: / }
+      backendRefs:
+        - name: foo-service
+          port: 5678

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -407,6 +407,56 @@ if flag_enabled "${TEST_MONITORING:-}"; then
   rm -f "$PROM_PF_LOG"
 fi
 
+# --- Gateway API controllers (opt-in via TEST_GATEWAY_API=yes) ---
+# Off by default because install-all does NOT enable Gateway API. Run
+# `make gateway-traefik` and/or `make gateway-istio` first, then
+# TEST_GATEWAY_API=yes make e2e-smoke. See docs/gateway-api-ingress.md.
+if flag_enabled "${TEST_GATEWAY_API:-}"; then
+  # Traefik Gateway API provider: GatewayClass Accepted + HTTPRoutes reach the
+  # SAME demo backends on *.gw.localdev.me via the Traefik LB IP — same pod as
+  # classic Ingress, proving the two providers coexist.
+  if "${KUBECTL[@]}" get gatewayclass traefik -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null | grep -q '^True$'; then
+    pass "Traefik GatewayClass is Accepted"
+  else
+    fail "Traefik GatewayClass not Accepted — run 'make gateway-traefik' first"
+  fi
+  check_curl "helloweb via Traefik Gateway API"       "http://${INGRESS_IP}/"        "Hello, world!"  -H "Host: helloweb.gw.localdev.me"
+  check_curl "golang /healthz via Traefik Gateway API" "http://${INGRESS_IP}/healthz" '"health":"ok"'  -H "Host: golang.gw.localdev.me"
+
+  # Istio Gateway controller: coexists with Traefik (distinct controllerName),
+  # gets its OWN LoadBalancer IP from cloud-provider-kind, fronts the SAME apps.
+  if "${KUBECTL[@]}" get gatewayclass istio -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null | grep -q '^True$'; then
+    pass "Istio GatewayClass is Accepted"
+  else
+    fail "Istio GatewayClass not Accepted — run 'make gateway-istio' first"
+  fi
+  ISTIO_GW_IP=""
+  for _ in $(seq 1 30); do
+    ISTIO_GW_IP=$("${KUBECTL[@]}" -n default get svc demo-istio -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
+    [ -n "$ISTIO_GW_IP" ] && break
+    sleep 2
+  done
+  if [ -n "$ISTIO_GW_IP" ]; then
+    pass "Istio gateway Service has its own LoadBalancer IP ($ISTIO_GW_IP)"
+    # K1.5 route-readiness: assigned IP != routable; poll until it serves.
+    ISTIO_OK=""
+    for _ in $(seq 1 30); do
+      if docker exec "$KIND_NODE" curl -sf --max-time 5 -H "Host: helloweb.localdev.me" "http://${ISTIO_GW_IP}/" 2>/dev/null | grep -qF "Hello, world!"; then
+        ISTIO_OK=yes; break
+      fi
+      sleep 2
+    done
+    if [ -n "$ISTIO_OK" ]; then
+      pass "helloweb reachable via Istio Gateway at ${ISTIO_GW_IP} (same backend as Traefik)"
+    else
+      fail "Istio Gateway at ${ISTIO_GW_IP} did not route to helloweb within 60s"
+    fi
+    check_curl "golang /healthz via Istio Gateway" "http://${ISTIO_GW_IP}/healthz" '"health":"ok"' -H "Host: golang.localdev.me"
+  else
+    fail "Istio gateway Service demo-istio got no LoadBalancer IP within 60s"
+  fi
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/scripts/kind-add-gateway-api-crds.sh
+++ b/scripts/kind-add-gateway-api-crds.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Install the Kubernetes Gateway API CRDs (standard channel). Idempotent and
+# version-pinned — both kind-add-gateway-traefik.sh and kind-add-gateway-istio.sh
+# depend on these, and the CRDs are install-if-absent so running it twice is safe.
+#
+# Standard channel = GatewayClass, Gateway, HTTPRoute, GRPCRoute, ReferenceGrant,
+# BackendTLSPolicy. For TCPRoute/TLSRoute/UDPRoute use the experimental channel
+# (not needed for the demo HTTP routes).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.." || exit 1
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+KUBECTL=(kubectl --context="kind-${KIND_CLUSTER_NAME}")
+
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+GATEWAY_API_VERSION=v1.5.1
+
+echo "=== Installing Gateway API CRDs (standard channel) ${GATEWAY_API_VERSION} ==="
+"${KUBECTL[@]}" apply -f \
+  "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+"${KUBECTL[@]}" wait --for=condition=Established \
+  crd/gateways.gateway.networking.k8s.io \
+  crd/httproutes.gateway.networking.k8s.io \
+  crd/gatewayclasses.gateway.networking.k8s.io \
+  --timeout=60s
+echo "Gateway API CRDs ready."

--- a/scripts/kind-add-gateway-istio.sh
+++ b/scripts/kind-add-gateway-istio.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Install Istio (minimal) as a SECOND Gateway API controller that coexists with
+# Traefik and fronts the SAME demo apps via its own LoadBalancer IP. Istio is NOT
+# a CNI — it installs over the existing kindnet cluster. For north-south ingress
+# we do not mesh the app pods (no sidecar injection); applying a Gateway with
+# gatewayClassName: istio auto-provisions a dedicated Envoy Deployment+Service.
+#
+# Requires `make install-all` first (cloud-provider-kind must be running so the
+# auto-provisioned gateway Service gets an external IP).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.." || exit 1
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+KUBECTL=(kubectl --context="kind-${KIND_CLUSTER_NAME}")
+HELM=(helm --kube-context="kind-${KIND_CLUSTER_NAME}")
+TIMEOUT="${1:-5m}"
+
+# renovate: datasource=github-releases depName=istio/istio
+ISTIO_VERSION=1.30.1
+ISTIO_CHARTS="https://istio-release.storage.googleapis.com/charts"
+
+# Gateway API CRDs first — Istio ≤1.29 + v1.5 CRDs crash-loops istiod; this repo
+# pins Istio 1.30.x (supports Gateway API v1.5.x) so the order is the only gate.
+"$SCRIPT_DIR/kind-add-gateway-api-crds.sh"
+
+echo "=== Installing Istio ${ISTIO_VERSION} (base + istiod, minimal) ==="
+helm repo add istio "$ISTIO_CHARTS" >/dev/null 2>&1 || true
+helm repo update istio >/dev/null
+"${HELM[@]}" upgrade --install istio-base istio/base \
+    --version "${ISTIO_VERSION}" --namespace istio-system --create-namespace \
+    --wait --timeout "${TIMEOUT}"
+"${HELM[@]}" upgrade --install istiod istio/istiod \
+    --version "${ISTIO_VERSION}" --namespace istio-system \
+    --wait --timeout "${TIMEOUT}"
+"${KUBECTL[@]}" -n istio-system rollout status deployment/istiod --timeout="${TIMEOUT}"
+
+echo "=== Applying Istio Gateway + HTTPRoutes (auto-provisions an Envoy gateway) ==="
+"${KUBECTL[@]}" apply -f k8s/gateway/istio-gateway.yaml
+# Applying the Gateway (gatewayClassName: istio) auto-creates Deployment+Service
+# named "<gateway>-<class>" = "demo-istio" in the default namespace.
+"${KUBECTL[@]}" -n default rollout status deployment/demo-istio --timeout="${TIMEOUT}"
+
+echo "Istio Gateway API installed. Its gateway Service gets its own LoadBalancer IP:"
+"${KUBECTL[@]}" -n default get svc demo-istio \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true
+echo ""
+echo "Reach the same demo apps via Istio, e.g.:"
+echo "  IP=\$(kubectl -n default get svc demo-istio -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+echo "  curl -H 'Host: helloweb.localdev.me' http://\$IP/"

--- a/scripts/kind-add-gateway-traefik.sh
+++ b/scripts/kind-add-gateway-traefik.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Enable Traefik's Kubernetes Gateway API provider IN ADDITION to classic Ingress,
+# and route the demo apps through a Gateway + HTTPRoutes. Traefik serves both the
+# existing networking.k8s.io/v1 Ingress AND Gateway API from the same pod — no
+# extra workload. Requires `make ingress-traefik` (or `make install-all`) first.
+#
+# The Gateway API demo uses *.gw.localdev.me hostnames so it doesn't collide with
+# the classic Ingress (*.localdev.me) on Traefik's shared web entrypoint, while
+# routing to the SAME backend Services.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.." || exit 1
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+KUBECTL=(kubectl --context="kind-${KIND_CLUSTER_NAME}")
+TIMEOUT="${1:-5m}"
+
+# Shared Gateway API CRDs (idempotent).
+"$SCRIPT_DIR/kind-add-gateway-api-crds.sh"
+
+# Reuse the chart version pinned in kind-add-traefik.sh — single source of truth,
+# Renovate-tracked there (avoids a second pin for the same dep).
+TRAEFIK_CHART_VERSION=$(awk -F= '/^TRAEFIK_CHART_VERSION=/{print $2; exit}' "$SCRIPT_DIR/kind-add-traefik.sh")
+CHART_URL="https://traefik.github.io/charts/traefik/traefik-${TRAEFIK_CHART_VERSION}.tgz"
+
+echo "=== Enabling Traefik Gateway API provider (chart v${TRAEFIK_CHART_VERSION}) ==="
+# --reuse-values keeps the original hostPort/nodeSelector/tolerations from
+# kind-add-traefik.sh; we only add the Gateway API provider + a GatewayClass.
+# gateway.enabled=false: we manage our own Gateway resource (k8s/gateway/) rather
+# than the chart's default, so the listener/hostnames are explicit and reviewable.
+# updateStrategy.type=Recreate is REQUIRED for this upgrade: Traefik binds
+# hostPort 80/443, and the default RollingUpdate (maxSurge=1) would create a
+# second pod that can never bind those ports while the old pod holds them →
+# the rollout deadlocks ("context deadline exceeded"). Recreate tears the old
+# pod down first (a brief restart), so the new pod with the Gateway provider
+# can bind the host ports. (The base install also sets this now.)
+helm --kube-context="kind-${KIND_CLUSTER_NAME}" upgrade traefik "$CHART_URL" \
+    --namespace traefik --reuse-values \
+    --set 'updateStrategy.type=Recreate' \
+    --set 'providers.kubernetesGateway.enabled=true' \
+    --set 'gatewayClass.enabled=true' \
+    --set 'gateway.enabled=false' \
+    --wait --timeout "${TIMEOUT}"
+
+"${KUBECTL[@]}" -n traefik rollout status deployment/traefik --timeout="${TIMEOUT}"
+
+echo "=== Applying demo Gateway + HTTPRoutes (*.gw.localdev.me) ==="
+"${KUBECTL[@]}" apply -f k8s/gateway/traefik-gateway.yaml
+"${KUBECTL[@]}" wait --for=condition=Programmed gateway/traefik-gateway -n default --timeout="${TIMEOUT}" || true
+
+echo "Traefik Gateway API enabled. Demo apps now also reachable via Gateway API, e.g.:"
+echo "  curl -H 'Host: helloweb.gw.localdev.me' http://localhost/"

--- a/scripts/kind-add-traefik.sh
+++ b/scripts/kind-add-traefik.sh
@@ -45,6 +45,7 @@ helm --kube-context="kind-${KIND_CLUSTER_NAME}" upgrade --install traefik "$CHAR
     --create-namespace --namespace traefik \
     --set 'ports.web.hostPort=80' \
     --set 'ports.websecure.hostPort=443' \
+    --set 'updateStrategy.type=Recreate' \
     --set-string 'nodeSelector.ingress-ready=true' \
     --set 'tolerations[0].key=node-role.kubernetes.io/control-plane' \
     --set 'tolerations[0].operator=Exists' \


### PR DESCRIPTION
Adds the Kubernetes **Gateway API alongside** classic Ingress (your choice: keep both, mirroring the `LB=metallb` dual-option pattern), plus a fact-checked comparison chapter. **Every routing path was spiked live on a real kind cluster** — both controllers fronting the **same** backends simultaneously.

## The question, answered (premise corrected, no guesses)
- **Is the project's Traefik "a gateway-ingress"?** It was running as **classic Ingress** (`networking.k8s.io/v1`), not Gateway API. Traefik v3 *can* do Gateway API; this PR enables it opt-in.
- **Traefik vs Antrea vs Istio?** Per the authoritative [implementations registry](https://gateway-api.sigs.k8s.io/implementations/): **Traefik** (conformant v1.5.1) and **Istio** (v1.4) are Gateway API controllers; **Antrea is not** — it's a CNI, its "gateway" is the `antrea-gw0` OVS dataplane interface. Per your call, the comparison swaps Antrea → **Cilium/Calico** (real CNI-integrated Gateway API).
- **Install all from the Makefile, Traefik default?** Yes — `gateway-traefik` + `gateway-istio` opt-in; classic Ingress stays default.
- **Advisable to run all? How do they route to the same apps?** Traefik + Istio coexist (distinct `controllerName`, distinct cloud-provider-kind LB IP) and an `HTTPRoute`'s `backendRefs` can point at the same Service from both — proven below. A CNI gateway (Cilium/Calico) is a *cluster-recreate*, not a co-install (one CNI per cluster).

## What's here
| | |
|---|---|
| **docs/gateway-api-ingress.md** | The comparison chapter — Traefik vs Istio vs Cilium/Calico, coexistence mechanics, advisability, all cited |
| **README** | "Ingress vs Gateway API" summary + link |
| `make gateway-traefik` | Enables Traefik's Gateway API provider (same pod keeps classic Ingress) + HTTPRoutes on `*.gw.localdev.me` |
| `make gateway-istio` | Istio (minimal) as a 2nd controller, own LB IP, same backends |
| `make gateway-api-crds` | Shared pinned CRD installer (gateway-api **v1.5.1**, istio **1.30.1** — Renovate-tracked) |
| e2e + `gateway-test.yml` | `TEST_GATEWAY_API=yes` block + weekly workflow |

## Live spike (real kind cluster)
- Traefik Gateway API: helloweb/golang/foo via `*.gw.localdev.me` ✓ — **classic Ingress still served by the same pod** ✓
- Istio: own LB IP `172.18.0.6` (distinct from Traefik `172.18.0.5`); same apps on `*.localdev.me` ✓
- GatewayClasses `traefik` + `istio` + `cloud-provider-kind` all Accepted simultaneously
- `TEST_GATEWAY_API=yes make e2e-smoke` → **27/27, 0 failed**

## Real fix surfaced by the spike
Traefik binds **hostPort 80/443**, so the default RollingUpdate deadlocks on `helm upgrade` (new pod can't bind ports the old pod holds → `context deadline exceeded`). Set `updateStrategy.type=Recreate` (correct for a single-replica hostPort controller) in the base install + gateway upgrade.

## Validation
`make lint` (shellcheck/actionlint/hadolint), `make renovate-validate` (+ extract confirms both new pins track), `make trivy-config`, `make check-toolchain-alignment` — all green. The `e2e` job here re-runs the base smoke; `gateway-test.yml` validates the Gateway API paths on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)