### PR TITLE
docs: fact-check corrections (README, CLAUDE.md, gateway-api-ingress.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@ scripts/              # Bash scripts for cluster lifecycle and app deployment
 tests/                # bats unit tests for scripts/lib.sh (make test)
 k8s/                  # Kubernetes manifests (kind config, Headlamp, NFS, gateway/, etc.)
 images/               # Dockerfiles (kubectl-test image)
-docs/diagrams/        # PlantUML C4 sources (.puml) + rendered PNGs (out/) + .drawio exports (drawio/)
+docs/diagrams/        # PlantUML C4 sources (.puml) + rendered PNGs (out/)
+                      #   (drawio/ holds on-demand `make diagrams-drawio` exports; gitignored)
+docs/                 # gateway-api-ingress.md (Gateway API / ingress comparison)
 vm/                   # Multipass cloud-init playbook
 .github/workflows/    # CI: ci.yml, e2e-metallb.yml, monitoring-test.yml,
-                      #   registry-test.yml, cleanup-runs.yml
+                      #   registry-test.yml, gateway-test.yml, cleanup-runs.yml
 ```
 
 ## Common Commands

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Headlamp listens on port 80 inside the cluster — reach it via the `headlamp-fo
 
 Source: [`docs/diagrams/c4-deployment.puml`](./docs/diagrams/c4-deployment.puml).
 
-- **`kind-control-plane` node** — kindest/node container running kube-apiserver/etcd/scheduler plus Traefik, Headlamp, and metrics-server (the latter pinned to control-plane via nodeSelector for kind compat).
+- **`kind-control-plane` node** — kindest/node container running kube-apiserver/etcd/scheduler plus Traefik (pinned here via the `ingress-ready=true` nodeSelector + control-plane toleration), with Headlamp and metrics-server scheduled cluster-wide.
 - **`kind-worker` node** — runs application workloads (demo apps, in-cluster NFS server pod, kube-prometheus-stack).
 - **`cloud-provider-kind`** — host docker container watching `Service: LoadBalancer` on the kind docker network; allocates LB IPs from the kind subnet (172.18.0.0/16 by default).
 - **`kindccm-<hash>`** — per-Service Envoy sidecars spawned by cloud-provider-kind that route LB-IP traffic to backend pods. Cleaned up by `make kind-destroy` (failing to clean these up was the cause of the K1.5 "connection reset on first curl" flake — see `scripts/kind-delete.sh`).
@@ -494,7 +494,7 @@ If you're running inside a Multipass VM, prefix with `multipass exec $NAME --` o
 
 ### metrics-server
 
-Required for `kubectl top` and HorizontalPodAutoscalers. On KinD, the default manifest is patched with `--kubelet-insecure-tls` (the KinD kubelet serving cert isn't signed by the cluster CA).
+Required for `kubectl top` and HorizontalPodAutoscalers. On KinD, it's installed via the `metrics-server` Helm chart with `--set args={--kubelet-insecure-tls}` (the KinD kubelet serving cert isn't signed by the cluster CA).
 
 ```bash
 make metrics-server

--- a/docs/gateway-api-ingress.md
+++ b/docs/gateway-api-ingress.md
@@ -87,7 +87,7 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/re
 
 All three rows below are **conformant** Gateway API controllers on the official
 [implementations registry](https://gateway-api.sigs.k8s.io/implementations/)
-(checked 2026-06): Traefik Proxy (v1.5.1), Istio (v1.4), Cilium (v1.5.1).
+(checked 2026-06): Traefik Proxy (v1.5.1), Istio (v1.4.0), Cilium (v1.5.1), Calico (v1.4.1).
 
 | | **Traefik** (this project's default proxy) | **Istio** | **Cilium / Calico** (CNI-integrated) |
 |---|---|---|---|
@@ -117,11 +117,10 @@ The chart can also auto-create a default `traefik` GatewayClass and a default
 `Gateway` (`gatewayClass.enabled` / `gateway.enabled`). `make gateway-traefik`
 enables the provider and applies the demo `Gateway` + `HTTPRoute`s.
 
-> ⚠️ **Doc-vs-spec conflict we verified:** Traefik's prose docs list `TLSRoute`
-> under the *standard* channel, but the Gateway API project (and Traefik's own
-> Helm chart comment) place `TLSRoute` in the **experimental** channel. Treat
-> `TLSRoute` as experimental — it needs `experimental-install.yaml` CRDs **and**
-> `experimentalChannel=true`.
+> ⚠️ **`TLSRoute` is an experimental-channel resource.** Traefik v3 supports it,
+> but it needs the `experimental-install.yaml` CRDs **and**
+> `providers.kubernetesGateway.experimentalChannel=true`. (`HTTPRoute` and
+> `GRPCRoute` are standard-channel and need neither.)
 
 ### Istio (Gateway API mode)
 
@@ -156,8 +155,9 @@ API conformance list:
 - **Cilium** — eBPF CNI with built-in Gateway API (GatewayClass `cilium`), served
   by an embedded **Envoy**; requires kube-proxy replacement and an LB/L2 path.
 - **Calico** — its **Calico Ingress Gateway** is a hardened distribution of the
-  **Envoy Gateway** project, provisioned by the Tigera operator from a
-  `GatewayAPI` CR.
+  **Envoy Gateway** project — enabled cluster-wide via the Tigera operator's
+  `GatewayAPI` installation CR, then provisioned per-gateway from a standard
+  `Gateway` resource.
 
 **These cannot be "added" to the running cluster.** A cluster has exactly one
 CNI, and kind installs `kindnetd` by default; switching CNIs is a
@@ -256,8 +256,8 @@ own `http://<istio-LB-IP>/` — same backends, different doors. No collision.
 | Target | What it does | Reach it at |
 |--------|--------------|-------------|
 | `make ingress-traefik` | **Default.** Traefik as a classic Ingress controller (`ingressClassName: traefik`), hostPort 80/443 | `http://<app>.localdev.me/` via `localhost` |
-| `make gateway-traefik` | Opt-in. Installs Gateway API CRDs (pinned), enables Traefik's Gateway API provider, applies a `Gateway` + `HTTPRoute`s for the demo apps | same Traefik entry (hostPort), now also via Gateway API |
-| `make gateway-istio` | Opt-in. Installs Gateway API CRDs + Istio (minimal) + an Istio `Gateway` + `HTTPRoute`s for the **same** demo apps | `http://<istio-gateway-LB-IP>/` |
+| `make gateway-traefik` | Opt-in. Installs Gateway API CRDs (pinned), enables Traefik's Gateway API provider, applies a `Gateway` + `HTTPRoute`s for the demo apps on `*.gw.localdev.me` | `curl -H 'Host: helloweb.gw.localdev.me' http://localhost/` (same Traefik hostPort, now also via Gateway API) |
+| `make gateway-istio` | Opt-in. Installs Gateway API CRDs + Istio (minimal) + an Istio `Gateway` + `HTTPRoute`s for the **same** demo apps on the original `*.localdev.me` hosts | `curl -H 'Host: helloweb.localdev.me' http://<istio-gateway-LB-IP>/` |
 
 Both `gateway-*` targets are idempotent on the shared Gateway API CRDs
 (install-if-absent), require **cloud-provider-kind** to be running (for LB IPs),


### PR DESCRIPTION
Full `*.md` validation pass — every version/statement/concept re-derived from the actual repo + primary sources (self-review-bias guard active on this session's own edits). All findings were minor; corrections:

**README**
- metrics-server is **not** pinned to control-plane via nodeSelector (only Traefik is — `kind-add-metrics-server.sh` sets only `args={--kubelet-insecure-tls}`).
- It's installed via the metrics-server **Helm chart**, not a "patched manifest".

**CLAUDE.md**
- `docs/diagrams/drawio/` is **gitignored** on-demand `make diagrams-drawio` output, not committed exports (the structure line implied committed).
- Added `docs/` (gateway-api-ingress.md) + `gateway-test.yml` to the structure list.

**docs/gateway-api-ingress.md** (verified against primary sources)
- Dropped the now-**stale** "Traefik docs say TLSRoute is standard" doc-vs-spec conflict — Traefik's current docs agree TLSRoute is experimental (conclusion unchanged).
- Istio conformance `v1.4`→`v1.4.0`; added Calico (`v1.4.1`) to the conformant list.
- Calico Ingress Gateway wording: enabled via the Tigera `GatewayAPI` installation CR, provisioned per-gateway from a standard `Gateway` (was imprecise).
- Clarified reach commands (Traefik GW on `*.gw.localdev.me`, Istio on `*.localdev.me`).

Validated: `make mermaid-lint` clean. No HIGH findings — the docs were substantially accurate; these are precision fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)