### PR TITLE
docs(readme): align description with GitHub About (Traefik + Gateway API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # kind-cluster — Local Kubernetes Lab on KinD
 
-Local Kubernetes lab on Docker via [KinD](https://kind.sigs.k8s.io/) — ingress, LoadBalancer (cloud-provider-kind, or MetalLB), Headlamp UI, RWX NFS storage, a local image registry, and Prometheus wired up out of the box. Run on your host, or inside a throwaway Multipass VM.
+Local Kubernetes lab on Docker via [KinD](https://kind.sigs.k8s.io/) — Traefik ingress (with opt-in [Gateway API](docs/gateway-api-ingress.md)), a LoadBalancer (cloud-provider-kind, or MetalLB), Headlamp UI, RWX NFS storage, a local image registry, and Prometheus wired up out of the box. Run on your host, or inside a throwaway Multipass VM.
 
 <img src="docs/diagrams/out/c4-context.png" alt="System Context — kind-cluster" width="700">
 


### PR DESCRIPTION
`/readme /repo-about` review.

**README itself: clean** — section order follows the canonical sequence, 0 scannability hits (placeholders/secrets/dead-badges/duplicate-slugs), badges correct, description factually accurate (just-validated in #88).

**Real finding — GitHub About drift (fixed via `gh repo edit`, no PR needed for metadata):**
- About said **"Dashboard"** → the project uses **Headlamp** (same migration the diagrams were stale on). → corrected.
- Topic **"nginx"** → stale (moved off ingress-nginx to **Traefik**). → removed; added `traefik`, `headlamp`, `gateway-api`, `cloud-provider-kind`.
- About omitted the **local registry** and **Gateway API**. → added.

New About: *"Local Kubernetes lab on Docker via KinD — Traefik ingress + opt-in Gateway API (Istio), LoadBalancer (cloud-provider-kind, MetalLB opt-in), Headlamp UI, RWX NFS, local registry, Prometheus. Run on host or in a Multipass VM."*

**This PR** aligns the README's one-paragraph description with the corrected About: names **Traefik ingress + opt-in Gateway API** explicitly (was the generic "ingress") with a link to `docs/gateway-api-ingress.md`. README ↔ About now tell the same story.

`make mermaid-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)