### PR TITLE
fix(deps): pin trivy back to 0.71.0 (v0.71.1 tag has no release — unblock main)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,7 +6,7 @@
 "aqua:koalaman/shellcheck"  = "0.11.0"
 "aqua:rhysd/actionlint"     = "1.7.12"
 "aqua:gitleaks/gitleaks"    = "8.30.1"
-"aqua:aquasecurity/trivy"   = "0.71.1"
+"aqua:aquasecurity/trivy"   = "0.71.0"
 "aqua:hadolint/hadolint"    = "2.14.0"
 "aqua:nektos/act"           = "0.2.89"
 "aqua:bats-core/bats-core"  = "1.13.0"


### PR DESCRIPTION
Greens `main`. Renovate #101 bumped trivy to `0.71.1`, but trivy pushed only the git **tag** `v0.71.1` — no published **release** (latest release is `v0.71.0`). mise/aqua installs from release assets → `mise install` 404s → `deps-tools`→`static-check`→`ci-pass` red on main. Pinning back to `0.71.0` (has a release). Renovate will re-propose `0.71.1` once trivy publishes that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)