### PR TITLE
fix(renovate): platformAutomerge:false — close the auto-merge registration race

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
   "labels": ["dependencies"],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",


### PR DESCRIPTION
Closes the race that let red Renovate PRs (#92/#99/#101) merge to `main`: `platformAutomerge: true` enables GitHub-native auto-merge ~1s after PR creation, and GitHub merges within ~3s — **before** the CI check run registers — so the required `ci-pass` check is still pending and never blocks. `platformAutomerge: false` makes Renovate self-merge on a later run only after re-confirming required checks are green (no pre-registration window).

**Not yet proven against a real red PR** — the only true proof is watching a genuinely-red Renovate PR fail to self-merge. Flagged per the rule this incident produced (`/renovate`: a merge gate is unproven until a red PR is observed blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)