### PR TITLE
docs: retitle README + sharpen description; unify TEST_INGRESS_ALT gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/kind-cluster)
 
-# kind-cluster — Local Kubernetes Lab on KinD
+# Local Kubernetes Lab on KinD
 
-Local Kubernetes lab on Docker via [KinD](https://kind.sigs.k8s.io/) — Traefik ingress (with opt-in [Gateway API](docs/gateway-api-ingress.md)), a LoadBalancer (cloud-provider-kind, or MetalLB), Headlamp UI, RWX NFS storage, a local image registry, and Prometheus wired up out of the box. Run on your host, or inside a throwaway Multipass VM.
+Local Kubernetes lab that runs in Docker via [KinD](https://kind.sigs.k8s.io/) — Traefik ingress with opt-in [Gateway API](docs/gateway-api-ingress.md) (seven coexisting controllers), a software LoadBalancer (cloud-provider-kind or MetalLB), the Headlamp dashboard, RWX (ReadWriteMany) NFS storage, a local image registry, and Prometheus/Grafana monitoring — all preconfigured. Run it on your host, or inside a throwaway Multipass VM.
 
 <img src="docs/diagrams/out/c4-context.png" alt="System Context — kind-cluster" width="450">
 

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -646,7 +646,7 @@ fi
 # and/or `make ingress-nginx` first, then TEST_INGRESS_ALT=yes make e2e-smoke.
 # Each alternative controller registers a distinct ingressClassName and gets its
 # OWN LoadBalancer IP, fronting the SAME demo apps as Traefik.
-if [ "${TEST_INGRESS_ALT:-}" = "yes" ]; then
+if flag_enabled "${TEST_INGRESS_ALT:-}"; then
   echo ""
   echo "=== Alternative classic Ingress controllers (TEST_INGRESS_ALT=yes) ==="
   # name|namespace|ingressClassName — discover each controller's LB Service by type.

--- a/tests/lib.bats
+++ b/tests/lib.bats
@@ -52,6 +52,12 @@ Forwarding from 127.0.0.1:2222 -> 80"
     [ "$output" = "foo-control-plane" ]
 }
 
+@test "kube_node_name: defaults to 'kind' when called with no argument" {
+    run kube_node_name
+    [ "$status" -eq 0 ]
+    [ "$output" = "kind-control-plane" ]
+}
+
 # --- flag_enabled ------------------------------------------------------------
 
 @test "flag_enabled: succeeds for exactly 'yes'" {


### PR DESCRIPTION
## Summary

Session-polish bundle from a `/upgrade-analysis` + `/test-coverage-analysis` + `/readme` + `/claude` pass.

### README
- **H1** dropped the `kind-cluster — ` repo-name prefix → **Local Kubernetes Lab on KinD**.
- **Description** rewritten for technical correctness + scannability:
  - "software LoadBalancer" (cloud-provider-kind/MetalLB provide an LB on a cluster with no cloud LB)
  - "seven coexisting controllers" — the lab's differentiator (all 7 Gateway API controllers run simultaneously; validated 63/63 live)
  - "RWX (ReadWriteMany)" spelled out; "Prometheus/Grafana monitoring" (kube-prometheus-stack)
  - "all preconfigured" replaces the overclaiming "wired up out of the box" (most add-ons are opt-in)
  - Every noun re-verified against source of truth (self-review-bias guard).

### test-coverage
- `scripts/e2e-smoke.sh`: `TEST_INGRESS_ALT` gate switched from an inline `[ "${TEST_INGRESS_ALT:-}" = "yes" ]` to the **`flag_enabled`** helper used by every other gate — behavior-identical, but now covered by the bats YAML-boolean guard and consistent with the centralized "exactly yes" convention.
- `tests/lib.bats`: added a `kube_node_name` no-argument case, covering the `${1:-kind}` default branch the two existing cases missed.

### Other pass results (no code changes needed)
- **/upgrade-analysis**: all 35 version pins confirmed CURRENT against authoritative upstream (3 parallel fact-checking agents); held items (trivy 0.71.0, MetalLB v0.16.0, gateway-api v1.5.1) still correctly held.
- **Diagrams**: `make diagrams-check` + `make mermaid-lint` both green — in sync.
- **/claude**: Skills section + Common Commands + Upgrade Backlog accurate.

`make static-check` green locally (lint + bats 11/11 + secrets + trivy + mermaid + diagrams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)