### PR TITLE
docs(readme): rewrite hero description (comparison-lab) + sync *.md facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Local Kubernetes Lab on KinD
 
-Local Kubernetes lab that runs in Docker via [KinD](https://kind.sigs.k8s.io/) — Traefik ingress with opt-in [Gateway API](docs/gateway-api-ingress.md) (seven coexisting controllers), a software LoadBalancer (cloud-provider-kind or MetalLB), the Headlamp dashboard, RWX (ReadWriteMany) NFS storage, a local image registry, and Prometheus/Grafana monitoring — all preconfigured. Run it on your host, or inside a throwaway Multipass VM.
+Spin up a Kubernetes cluster in Docker ([KinD](https://kind.sigs.k8s.io/)) and compare 3 classic Ingress and 7 [Gateway API](docs/gateway-api-ingress.md) controllers coexisting on it — each on its own LoadBalancer IP, all routing the same demo apps. The LoadBalancer (cloud-provider-kind or MetalLB), Headlamp dashboard, Prometheus/Grafana, ReadWriteMany NFS, and local registry are opt-in; run on your host or a throwaway Multipass VM.
 
 <img src="docs/diagrams/out/c4-context.png" alt="System Context — kind-cluster" width="450">
 
@@ -137,7 +137,7 @@ Every controller's `Gateway` gets its **own** LoadBalancer IP from cloud-provide
 kubectl get gateway
 # NAME              CLASS      ADDRESS      PROGRAMMED
 # traefik-gateway   traefik    172.18.0.4   True
-# demo              istio      172.18.0.6   True
+# istio             istio      172.18.0.6   True
 # ngf               nginx      172.18.0.7   True
 # contour           contour    172.18.0.8   True
 # eg                envoy      172.18.0.9   True

--- a/docs/gateway-api-ingress.md
+++ b/docs/gateway-api-ingress.md
@@ -4,14 +4,15 @@
 > the strategic successor to classic **Ingress**, and a fact-checked comparison of
 > the headline Gateway API implementations — **Traefik**, **Istio**, and a
 > CNI-integrated option (**Cilium** / **Calico**) — plus additional opt-in
-> conformant controllers (**NGINX Gateway Fabric**, **Contour**) wired as extra
-> GatewayClasses, including how to run more than one of them in the same cluster.
+> conformant controllers (**NGINX Gateway Fabric**, **Contour**, **Envoy Gateway**,
+> **kgateway**, **Kong**) wired as extra GatewayClasses, including how to run more
+> than one of them in the same cluster.
 >
 > Every version, conformance status, and behaviour below is cited to a primary
-> source (see [References](#references)). Verified 2026-06-06 against Gateway API
-> **v1.5.1**, Traefik chart **40.2.0** (appVersion **v3.7.1**), Istio **1.30.1**,
-> NGINX Gateway Fabric **2.6.3**, Contour **v1.33.5**,
-> Cilium **v1.19.4**, Calico **v3.32.0**.
+> source (see [References](#references)). Verified 2026-06-15 against Gateway API
+> **v1.5.1**, Traefik chart **40.3.0** (appVersion **v3.7.4**), Istio **1.30.1**,
+> NGINX Gateway Fabric **2.6.3**, Contour **v1.33.5**, Envoy Gateway **v1.8.1**,
+> kgateway **v2.3.3**, Kong/KIC chart **0.24.0**, Cilium **v1.19.4**, Calico **v3.32.0**.
 
 ## TL;DR
 
@@ -37,6 +38,11 @@
   - `make gateway-contour` — installs **Project Contour** via its **Gateway
     provisioner**; each Gateway gets its own Envoy data plane + LoadBalancer IP,
     fronting the **same** demo apps.
+  - `make gateway-envoy` / `make gateway-kgateway` / `make gateway-kong` — three
+    more conformant controllers (**Envoy Gateway** and **kgateway** are CNCF;
+    **Kong**/KIC binds its GatewayClass to one shared proxy in unmanaged mode),
+    each fronting the **same** demo apps on its own LB IP. All seven are detailed
+    in the [wiring table](#how-this-project-wires-it).
 - **Antrea is not in this comparison.** Antrea is a **CNI**, not a Gateway API
   controller — its "gateway" (`antrea-gw0`) is an Open vSwitch dataplane interface,
   unrelated to `gateway.networking.k8s.io`. If you want a **CNI-integrated**
@@ -220,9 +226,9 @@ GatewayClasses coexist and each controller ignores the other's Gateways.
 
 **2. Same app, two front doors.** An `HTTPRoute` names its Gateway in
 `parentRefs` and its Services in `backendRefs`; nothing ties a Service to one
-route. So `demo-route-traefik` (→ Traefik Gateway) and `demo-route-istio`
-(→ Istio Gateway) can both carry `backendRefs: helloweb` — both gateways front
-the identical pods.
+route. So an `HTTPRoute` parented to the Traefik Gateway and one parented to the
+Istio Gateway can both carry `backendRefs: helloweb` — both gateways front the
+identical pods.
 
 **3. The only real contention is the entry-point address:**
 


### PR DESCRIPTION
Rewrites the README hero description (chosen from a 3-candidate research spike — comparison-lab framing, corrects the ingress under-representation and the "all preconfigured" overclaim), fixes the `kubectl get gateway` example `demo`→`istio`, and resolves the 4 review findings in `docs/gateway-api-ingress.md` (stale Traefik chart 40.2.0→40.3.0, header/TL;DR now list all 7 Gateway API controllers, invented route names made generic, Verified date refreshed). Docs-only; `make static-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)