### PR TITLE
chore(ci): add --pull=false to ci-run's act invocation (containerd-store RWLayer race)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,12 +224,17 @@ ci-run: deps-tools deps-docker
 	@docker container prune -f 2>/dev/null || true
 	@# Random artifact port + dir so concurrent ci-run invocations from other
 	@# projects don't collide on act's host-global defaults (34567, /tmp/act-artifacts).
+	@# --pull=false: act force-pulls the runner image by default; on Docker's
+	@# containerd image store (this host) re-pulling while a container references
+	@# the layers triggers the snapshotter "RWLayer ... unexpectedly nil" race
+	@# (misleading exit 137). Cached image is reused; first run still pulls.
 	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
 	for j in static-check docker; do \
 		echo "==== act push --job $$j ===="; \
 		act push --job $$j \
 			--container-architecture linux/amd64 \
+			--pull=false \
 			-P ubuntu-24.04=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" || exit 1; \


### PR DESCRIPTION
## What
Adds `--pull=false` to the `act` invocation in the `ci-run` Makefile target (local-dev-only; not a CI job).

## Why (fact-verified on this host)
`act` force-pulls the runner image by default (`--pull` defaults to `true`). On Docker's **containerd image store** — confirmed on this host: `Server Version: 29.5.3`, `Storage Driver: overlayfs`, `driver-type: io.containerd.snapshotter.v1` — re-pulling the image while a container references its layers triggers the snapshotter `RWLayer … unexpectedly nil` race and a misleading exit 137 (looks like OOM, isn't). `--pull=false` reuses the cached image; the first run still pulls when the image is missing.

Surfaced by a `/makefile` audit (the one LOW finding; the rest of the Makefile audited clean — 0 HIGH, 0 MEDIUM).

## Verified
- [x] `act --version` = 0.2.89, `act --help` shows `-p, --pull` — flag is valid
- [x] containerd image store confirmed via `docker info` (precondition for the race holds here)
- [x] `make ci` (static-check + renovate-validate) green; `make help` aligned
- [x] `make ci-run` runs clean locally with `--pull=false` (deep verify — see PR thread)
- [ ] PR CI green (note: CI does **not** run `ci-run`, so PR CI confirms the Makefile is still valid, not the flag itself — the flag is verified by the local `make ci-run` above)