### PR TITLE
docs(readme): correct hero — cloud-provider-kind is the default LB, add trusted HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Local Kubernetes Lab on KinD
 
-Spin up a Kubernetes cluster in Docker ([KinD](https://kind.sigs.k8s.io/)) and compare 3 classic Ingress and 7 [Gateway API](docs/gateway-api-ingress.md) controllers coexisting on it — each on its own LoadBalancer IP, all routing the same demo apps. The LoadBalancer (cloud-provider-kind or MetalLB), Headlamp dashboard, Prometheus/Grafana, ReadWriteMany NFS, and local registry are opt-in; run on your host or a throwaway Multipass VM.
+Spin up a Kubernetes cluster in Docker ([KinD](https://kind.sigs.k8s.io/)) and compare 3 classic Ingress and 7 [Gateway API](docs/gateway-api-ingress.md) controllers coexisting on it — each on its own LoadBalancer IP, all routing the same demo apps. LoadBalancer IPs come from cloud-provider-kind by default (MetalLB is a drop-in alternative). Trusted local-CA HTTPS, the Headlamp dashboard, Prometheus/Grafana, ReadWriteMany NFS, and a local registry are opt-in; run on your host or a throwaway Multipass VM.
 
 <img src="docs/diagrams/out/c4-context.png" alt="System Context — kind-cluster" width="450">
 


### PR DESCRIPTION
Two factual fixes to the hero paragraph: (1) cloud-provider-kind is the **default** LoadBalancer (part of `make install-all`), not opt-in — reworded so it's not lumped with the opt-in list; MetalLB is the drop-in alternative. (2) Added **trusted local-CA HTTPS** (cert-manager, PR #122) to the opt-in list — the session's headline feature, previously missing. 3-classic-Ingress / 7-Gateway-API counts verified accurate. README-only → docs-classified.