### PR TITLE
docs: validate both docs for technical correctness + add /readme validation rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,12 @@ Use the following skills when working on related files:
 |---------|-------|
 | `Makefile` | `/makefile` |
 | `renovate.json` | `/renovate` |
-| `README.md` | `/readme` |
+| `README.md`, `docs/gateway-api-ingress.md` | `/readme` |
 | `.github/workflows/*.{yml,yaml}` | `/ci-workflow` |
 
 When spawning subagents, always pass conventions from the respective skill into the agent's prompt.
+
+**`/readme` in this repo MUST validate BOTH `README.md` AND `docs/gateway-api-ingress.md` for technical correctness of every statement and version on each invocation** (BLOCKING). Both docs carry dense version tables + feature/comparison matrices that Renovate cannot touch, so they drift silently. On every `/readme` pass, re-derive — do not trust the existing prose:
+- **Versions** — every controller/chart/tool version cell against its source of truth: `.mise.toml` (kind, kubectl, trivy, act, gitleaks, hadolint, shellcheck, actionlint, jq, bats) and the `scripts/kind-add-*.sh` pins (`ISTIO_VERSION`, `NGF_VERSION`, `CONTOUR_VERSION`, `ENVOY_GATEWAY_VERSION`, `KGATEWAY_VERSION`, `KONG_VERSION`, `TRAEFIK_CHART_VERSION`, `HAPROXY_INGRESS_VERSION`, `NGINX_INGRESS_VERSION`, `CERT_MANAGER_VERSION`, `METALLB_VERSION`, `CSI_DRIVER_NFS_VERSION`, `METRICS_SERVER_CHART_VERSION`, `HEADLAMP_CHART_VERSION`) + `CLOUD_PROVIDER_KIND_VERSION` in the Makefile.
+- **`make` targets** — every `make <x>` referenced must exist in the Makefile.
+- **Statements / external facts** — Gateway API conformance-registry entries, CNCF maturity levels (Graduated/Incubating/Sandbox), vendored `gateway-api` client versions (the ≥ v1.2.0 `supportedFeatures` floor), EOL/archival status (Weave Net, ingress-nginx), and version-compat claims (e.g. Istio ≤ 1.29 + GW API v1.5 crash-loop) against primary sources, not memory. Treat any claim that can't be confirmed against a primary source as a flagged finding, not an assumption.

--- a/docs/gateway-api-ingress.md
+++ b/docs/gateway-api-ingress.md
@@ -102,7 +102,7 @@ kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/re
 
 All three rows below are **conformant** Gateway API controllers on the official
 [implementations registry](https://gateway-api.sigs.k8s.io/implementations/)
-(checked 2026-06): Traefik Proxy (v1.5.1), Istio (v1.4.0), Cilium (v1.5.1), Calico (v1.4.1).
+(checked 2026-06): Traefik Proxy (v1.5.1), Istio (v1.5.1), Cilium (v1.5.1), Calico (v1.4.1).
 
 | | **Traefik** (this project's default proxy) | **Istio** | **Cilium / Calico** (CNI-integrated) |
 |---|---|---|---|


### PR DESCRIPTION
Addresses two requests: (1) validate README.md + docs/gateway-api-ingress.md for technical correctness of statements and versions, (2) make `/readme` always validate `gateway-api-ingress.md` in this repo.

## Validation (fact-checked against primary sources)
- **One real error fixed:** gateway-api-ingress.md cited Istio's Gateway API **conformance-registry** version as `v1.4.0`; the [registry](https://gateway-api.sigs.k8s.io/implementations/) shows **v1.5.1**. Corrected.
- **Everything else confirmed:** Traefik/Cilium/Calico conformance versions · Kong split (KIC v1.2.1 / Operator v1.5.1, KIC vendors gateway-api v1.3.0) · CNCF maturity (Cilium/Istio Graduated, Contour Incubating, kgateway Sandbox) · Envoy CNCF-Graduated + Envoy Gateway subproject · ingress-nginx March 2026 retirement · Weave Net archived 2024 · cert-manager 1.15 `enableGatewayAPI` · Istio ≤1.29 + GW API v1.5 crash-loop (IST0176) · supportedFeatures `[]string`→`[]object` in v1.2.0 (#3200).
- **Vendored versions independently confirmed via go.mod:** Envoy Gateway v1.8.1 → `gateway-api v1.5.1`, kgateway v2.3.3 → `v1.5.1` (the README "Vendored gateway-api" row is correct — vendored ≠ conformance-submission version).
- All version pins in both docs match the `scripts/` + `.mise.toml` source of truth.

## Rule
CLAUDE.md Skills section now maps `docs/gateway-api-ingress.md` → `/readme` and adds a BLOCKING note: `/readme` in this repo must validate BOTH docs for every statement + version on each pass, re-deriving from source of truth (and primary sources for external/conformance/CNCF/EOL claims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)