### PR TITLE
fix(ci): ingress-test cert-manager must run with ENABLE_GATEWAY_API=false

### DIFF
--- a/.github/workflows/ingress-test.yml
+++ b/.github/workflows/ingress-test.yml
@@ -83,7 +83,22 @@ jobs:
 
       # Trusted HTTPS via a local CA (cert-manager + sslip.io): make tls-all wires
       # a *.<lb-ip>.sslip.io cert + Ingress spec.tls onto each alt classic ingress.
+      #
+      # ENABLE_GATEWAY_API=false is REQUIRED here: this job's TLS path is classic
+      # Ingress only (HAProxy + NGINX Inc.) with NO Gateway resources, so the
+      # tls-all run wires only the classic-Ingress sslip.io certs (its Gateway
+      # specs all skip). cert-manager's controller hard-crashes at startup when
+      # enableGatewayAPI=true but the Gateway API CRDs are absent
+      # ("the Gateway API CRDs do not seem to be present, but
+      # ExperimentalGatewayAPISupport is set to true"). This job installs no
+      # Gateway API CRDs — and since cloud-provider-kind now runs with
+      # --gateway-channel disabled (commit e0824a1) it no longer side-installs
+      # the embedded GW API CRDs that previously masked this. Mirrors
+      # e2e-metallb.yml's classic-Ingress-only cert-manager step. See
+      # scripts/kind-add-cert-manager.sh.
       - name: Install cert-manager + local CA
+        env:
+          ENABLE_GATEWAY_API: "false"
         run: make cert-manager
 
       - name: Wire TLS (per-ingress sslip.io)


### PR DESCRIPTION
## Problem

The **Ingress (alternatives) E2E** workflow has failed on every run since 2026-06-19 (last green 2026-06-15). The `Install cert-manager + local CA` step times out after 5 min:

```
error: timed out waiting for the condition on clusterissuers/local-ca
make: *** [Makefile:330: cert-manager] Error 1
```

## Root cause

`e0824a1` started cloud-provider-kind with `--gateway-channel disabled`, so CPK no longer **side-installs its embedded Gateway API CRDs** (v1.4.0) at startup. The ingress-test job ran `make cert-manager` with the default `ENABLE_GATEWAY_API=true`, which **crash-loops the cert-manager controller** when no Gateway API CRDs are present:

```
error executing command err="the Gateway API CRDs do not seem to be present, but
ExperimentalGatewayAPISupport is set to true. Please install the gateway-api CRDs."
```

The controller's issuer/certificate reconcilers then never run, so `local-ca` never goes Ready. (helm `--wait` still returns 0 — it passes on the webhook/cainjector before the controller enters CrashLoopBackOff — which is why the failure surfaces only at the `local-ca` wait, exactly as in the CI log.) The ingress-test path was unknowingly relying on CPK's CRD side-effect, which `--gateway-channel disabled` removed.

## Fix

This job's TLS path is **classic Ingress only** (HAProxy + NGINX Inc.) with no Gateway resources, so set `ENABLE_GATEWAY_API=false` on the cert-manager step. `tls-all`'s Gateway specs all skip; only the classic-Ingress `*.sslip.io` certs are wired. This mirrors the identical, passing pattern in `e2e-metallb.yml`.

## Verification

Local A/B reproduction on a bare kind cluster (no GW API CRDs), cert-manager v1.20.2:

| enableGatewayAPI | controller | local-ca |
|---|---|---|
| `true`  | CrashLoopBackOff | **TIMED OUT ❌** (reproduces CI) |
| `false` | Running | **READY ✅** |

This workflow is gated to `push: [main]` (no `pull_request` trigger), so it will be verified on this branch via `workflow_dispatch` before merge.