### PR TITLE
docs: sync Traefik chart 41.0.0 → 41.0.1 (follows Renovate #168)

### DIFF
--- a/docs/gateway-api-ingress.md
+++ b/docs/gateway-api-ingress.md
@@ -10,7 +10,7 @@
 >
 > Every version, conformance status, and behaviour below is cited to a primary
 > source (see [References](#references)). Verified 2026-06-29 against Gateway API
-> **v1.5.1**, Traefik chart **41.0.0** (appVersion **v3.7.5**), Istio **1.30.2**,
+> **v1.5.1**, Traefik chart **41.0.1** (appVersion **v3.7.5**), Istio **1.30.2**,
 > NGINX Gateway Fabric **2.6.6**, Contour **v1.33.5**, Envoy Gateway **v1.8.1**,
 > kgateway **v2.3.5**, Kong/KIC chart **0.24.0**, Cilium **v1.19.4**, Calico **v3.32.0**.
 


### PR DESCRIPTION
Closes the forward-looking doc-drift item from the `/upgrade-analysis` re-run: Renovate PR #168 bumped `TRAEFIK_CHART_VERSION` 41.0.0 → 41.0.1, which left `docs/gateway-api-ingress.md`'s verification-header snapshot (`Traefik chart **41.0.0**`) one patch stale.

- **41.0.1 ships the same appVersion `v3.7.5`** (verified against `traefik-helm-chart/v41.0.1/.../Chart.yaml`), so only the chart number changes.
- README L314 (`chart 41.x`) and the diagram tech-strings (`v3 (41.x)`) already cover 41.0.1 — no change.
- The L402 line (`chart 40.3.0 / Traefik v3.7.4`) is a **dated 2026-06-15 historical verification note** — left as-is per append-to-history.

Doc-only change → paths-filter `code=false` → `ci-pass` via the fast path.