### PR TITLE
chore: buffer github-side kubectl/kind pins to match mise 3-day hold

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,11 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Mirror the mise manager's 3-day minimumReleaseAge onto the github-based kubectl (kubernetes/kubernetes) and kind (kubernetes-sigs/kind) pins that check-toolchain-alignment cross-checks against their .mise.toml aqua: twins. Without this, the github-tracked half (Makefile KUBECTL_VERSION, images/Dockerfile ARG, vm/cloud-init.yaml) becomes eligible ~day 0 while its buffered mise twin (aqua:kubernetes/kubectl, aqua:kubernetes-sigs/kind) waits until day 3, so the grouped kubectl/kind PR opens with ONLY the github half and check-toolchain-alignment reddens it for ~3 days every patch (observed: PR #225, kubectl v1.36.2->v1.36.3, 2026-07-23). The group already cannot MERGE before day 3 (the alignment gate blocks the partial state under platformAutomerge:false + required ci-pass), so buffering the github half adds no real merge delay — it only stops opening a doomed-red PR early, and both halves then bump atomically. Does NOT cover kindest/node: the node-image K8s version is a separate axis, not compared by the alignment gate.",
+      "matchDepNames": ["kubernetes/kubernetes", "kubernetes-sigs/kind"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "description": "Group GitHub Actions into one PR",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"


### PR DESCRIPTION
## What

Adds a Renovate `packageRule` mirroring the mise manager's existing 3-day `minimumReleaseAge` onto the **github-based** kubectl (`kubernetes/kubernetes`) and kind (`kubernetes-sigs/kind`) pins.

## Why

The `kubectl` (and `kind`) Renovate groups split on **every patch**. The four kubectl pins use two datasources:

- `Makefile` / `images/Dockerfile` / `vm/cloud-init.yaml` → `github-tags depName=kubernetes/kubernetes` (**no** patch-level buffer)
- `.mise.toml` → `aqua:kubernetes/kubectl` (held 3 days by the existing `matchManagers:["mise"]` buffer)

So the github half becomes eligible ~day 0 while the mise twin is held to day 3. Renovate opens the grouped PR with **only the github half**, and `check-toolchain-alignment` reddens it for ~3 days every patch. This is exactly the currently-open **PR #225** (kubectl `v1.36.2→v1.36.3`):

```
ERROR: kubectl version drift — Makefile=1.36.3 .mise.toml=1.36.2 Dockerfile=1.36.3 cloud-init=1.36.3
make: *** [Makefile:255: check-toolchain-alignment] Error 1
```

The gate is working; the split is the defect. Buffering the github half so both halves become eligible together makes the group bump **atomically**. No real merge delay — the group already cannot merge before day 3 (the alignment gate blocks the partial state under `platformAutomerge:false` + required `ci-pass`); this only stops opening a doomed-red PR early.

## Verification (validate-by-effect, per the /renovate skill)

`renovate --platform=local --dry-run=lookup` before vs after, for the `kubernetes/kubernetes` → `v1.36.3` update object (published ~1h before the run, `newVersionAgeInDays: 0`):

| | pending state |
|---|---|
| **before** (main) | no `pendingChecks` → eligible day 0 (the split) |
| **after** (this PR) | `pendingChecks: true` on all 3 github pins → held, matching `aqua:kubernetes/kubectl` |

`renovate-config-validator`: `Config validated successfully`.

## Notes

- Does **not** buffer `kindest/node` (docker datasource) — the node-image K8s version is a separate axis, not compared by `check-toolchain-alignment`.
- **PR #225 is left to self-heal**: its `.mise.toml` half's 3-day buffer expires ~2026-07-26, then Renovate rebases the alignment fix in and it goes green. Not manually bumped (that would defeat the buffer + risk a Renovate rebase clobber).
