### PR TITLE
chore: track kubectl version in README so it bumps with the pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,18 @@
       "matchStrings": [
         "plantuml-stdlib/C4-PlantUML/(?<currentValue>v\\d+\\.\\d+\\.\\d+)/"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track the kubectl version shown in prose in README.md — the Pinned-version table row (`| [kubectl](...) | 1.36.2 |`) and the cloud-init bootstrap prose (`... KinD v0.32.0, kubectl v1.36.2, ...`) — so the docs bump in lockstep with the functional pins instead of drifting on every patch. datasource=github-tags depName=kubernetes/kubernetes matches the Makefile/Dockerfile/cloud-init pins, so these land in the same 'kubectl' group and inherit the 3-day github-half minimumReleaseAge buffer. extractVersion strips the leading v from the github tags so both the bare table value and the `kubectl v...` prose capture/write bare digits (the literal `v` in the prose is outside the capture and stays). The prose matchString is anchored on the `KinD v..., kubectl v...` bootstrap shape (not a bare `kubectl vX.Y.Z`) so it can only match the install line, never a future version-compat note. NOTE: only kubectl is tracked here; the other README version-table rows (kind/jq/shellcheck/trivy/...) have the same latent drift but are a deliberate follow-up — a whole-table approach means many fragile prose regexes, and a whole-table *drift gate* would red every mise-tool bump PR until the README is regenerated, breaking mise automerge.",
+      "managerFilePatterns": ["/^README\\.md$/"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "matchStrings": [
+        "\\[kubectl\\]\\([^)]+\\)\\s*\\|\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*\\|",
+        "KinD v[\\d.]+, kubectl v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## What
Adds a `custom.regex` Renovate manager over `README.md` that tracks the kubectl version shown in prose in **two** places — the Pinned-version table row (`| [kubectl](...) | 1.36.2 |`) and the cloud-init bootstrap line (`kubectl v1.36.2`).

## Why
Both README locations were tracked by neither `check-toolchain-alignment` nor any Renovate manager, so they **drift on every kubectl patch** (the functional pins update, the docs go stale). This is the recurring "manual doc re-sync after a Renovate bump" chore.

## How
`datasource=github-tags depName=kubernetes/kubernetes` matches the Makefile/Dockerfile/cloud-init pins, so both README pins:
- land in the existing **`kubectl` group** → bump in the same PR as the functional pins, and
- inherit the **3-day github-half buffer** from #226 → all six kubectl pins now become eligible together (atomic bump, no partial-red PR).

`extractVersion=^v(?<version>.*)$` strips the leading `v` from the github tags, so the bare table value writes `1.36.3` and the `kubectl v...` prose keeps its literal `v` (capture is the digits only) → `kubectl v1.36.3`.

## Verification (validate-by-effect)
`renovate --platform=local --dry-run=lookup`:
- `README.md` manager matches 1 file; extracts both kubectl replaceStrings.
- `kubernetes/kubernetes` update-object count: **3 → 5** (the 2 new README pins).
- Both README pins: `newValue: 1.36.3`, `updateType: patch`, `branchName: renovate/kubectl`, **`pendingChecks: true`**.
- `renovate-config-validator`: `Config validated successfully`.

## Scope
Only **kubectl** is tracked. The rest of the README version-table rows (kind/jq/shellcheck/actionlint/gitleaks/trivy/hadolint/act/bats) have the **same latent drift** but are a deliberate follow-up:
- `jq` is Renovate-untrackable (aqua `jq-` tag prefix — documented in CLAUDE.md's Upgrade Backlog).
- A whole-table *drift gate* would conflict with mise automerge (it would red every mise bump PR until the README is regenerated).

No README content changes here (the current `1.36.2` is correct); this only adds tracking so future bumps stay in sync.
