### PR TITLE
chore(all): update kubectl to v1.36.3 (atomic; resolves #225)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -16,4 +16,4 @@
 # 2026-06-29). It detects jq but never proposes a bump. Check `mise latest aqua:jqlang/jq`.
 "aqua:jqlang/jq"            = "1.8.2"
 "aqua:kubernetes-sigs/kind" = "0.32.0"
-"aqua:kubernetes/kubectl"   = "1.36.2"
+"aqua:kubernetes/kubectl"   = "1.36.3"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PLANTUML_VERSION := 1.2026.6
 # renovate: datasource=docker depName=ghcr.io/andriykalashnykov/puml2drawio
 PUML2DRAWIO_VERSION := 1.6.1
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
-KUBECTL_VERSION := v1.36.2
+KUBECTL_VERSION := v1.36.3
 # KIND_NODE_IMAGE is bumped together with kind in .mise.toml per KinD release notes.
 # Digest-pinned for reproducibility; Renovate bumps tag + @sha256 together.
 # renovate: datasource=docker depName=kindest/node

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Pinned in [`.mise.toml`](./.mise.toml), auto-installed by `make deps` via [mise]
 | Tool | Pinned version |
 |------|----------------|
 | [kind](https://kind.sigs.k8s.io/) | 0.32.0 |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | 1.36.2 |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | 1.36.3 |
 | [jq](https://github.com/jqlang/jq) | 1.8.2 |
 | [shellcheck](https://github.com/koalaman/shellcheck) | 0.11.0 |
 | [actionlint](https://github.com/rhysd/actionlint) | 1.7.12 |
@@ -522,7 +522,7 @@ First boot takes ~3–5 min (Ubuntu cloud image download, apt-get install, docke
 
 The cloud-init playbook (`vm/cloud-init.yaml`) runs once at first boot:
 
-1. Installs Docker CE, KinD v0.32.0, kubectl v1.36.2, helm v4.2.2
+1. Installs Docker CE, KinD v0.32.0, kubectl v1.36.3, helm v4.2.2
 2. Installs `nfs-kernel-server`, exports `/srv/k8s_nfs_storage`
 3. Clones this repo to `/home/ubuntu/kind-cluster`
 4. Writes `/var/lib/kind-cluster-bootstrapped` as the finished sentinel — `vm-up.sh` polls this file.

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Andriy Kalashnykov" description="Kubernetes testing image"
 # invocations. Renovate tracks this ARG via a Dockerfile custom.regex manager;
 # the kubectl packageRule groups it with the Makefile + .mise.toml + cloud-init.
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
-ARG KUBECTL_VERSION=v1.36.2
+ARG KUBECTL_VERSION=v1.36.3
 
 # Non-root identity. Overridable for hosts whose UID/GID mapping needs it.
 ARG APP_UID=10001

--- a/vm/cloud-init.yaml
+++ b/vm/cloud-init.yaml
@@ -50,7 +50,7 @@ write_files:
       # renovate: datasource=github-releases depName=kubernetes-sigs/kind
       KIND_VERSION=v0.32.0
       # renovate: datasource=github-tags depName=kubernetes/kubernetes
-      KUBECTL_VERSION=v1.36.2
+      KUBECTL_VERSION=v1.36.3
       # renovate: datasource=github-releases depName=helm/helm
       HELM_VERSION=v4.2.3
 


### PR DESCRIPTION
## What
Lands the **kubectl `v1.36.2 → v1.36.3`** patch atomically across **all six** pins in one commit: `Makefile`, `images/Dockerfile`, `vm/cloud-init.yaml`, `.mise.toml`, and both README locations (version table + cloud-init prose). `check-toolchain-alignment` stays green.

## Why (resolves the failing PR #225)
Renovate PR #225 opened this bump as a **partial** one — only the 3 github-tags pins, because `.mise.toml`'s `aqua:` twin was held by the mise 3-day buffer — so it was red on `check-toolchain-alignment` and **could not merge** (merging a partial bump would red `main`). Landing the full atomic bump here retires it: once `main` carries `1.36.3` everywhere, Renovate **auto-closes #225** (no diff left).

The recurrence is already fixed on `main` — #226 buffers the github half so future kubectl patches bump atomically, and #227 tracks the README kubectl version so it moves with the pins.

## Safe to override the 3-day mise buffer here
The buffer exists solely to avoid a `mise install` 404 when a tag exists before its release binary. Verified that does **not** apply to v1.36.3:
- `dl.k8s.io/release/v1.36.3/bin/linux/{amd64,arm64}/kubectl` → `200`.
- `mise install aqua:kubernetes/kubectl@1.36.3` → installed, checksum OK, `kubectl version --client` → `v1.36.3`.
- CI's `e2e` runs `make deps` (real `mise install`) as the end-to-end proof.
