### PR TITLE
docs: remove the redundant README version table (single-source .mise.toml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,7 @@ User provides (host-level):
 | [curl](https://curl.se/) | latest | Download helpers used by scripts |
 | [base64](https://command-not-found.com/base64) | latest | Token decoding for Headlamp access |
 
-Pinned in [`.mise.toml`](./.mise.toml), auto-installed by `make deps` via [mise](https://mise.jdx.dev) (mise itself is bootstrapped into `~/.local/bin` on first run):
-
-| Tool | Pinned version |
-|------|----------------|
-| [kind](https://kind.sigs.k8s.io/) | 0.32.0 |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | 1.36.3 |
-| [jq](https://github.com/jqlang/jq) | 1.8.2 |
-| [shellcheck](https://github.com/koalaman/shellcheck) | 0.11.0 |
-| [actionlint](https://github.com/rhysd/actionlint) | 1.7.12 |
-| [gitleaks](https://github.com/gitleaks/gitleaks) | 8.30.1 |
-| [trivy](https://github.com/aquasecurity/trivy) | 0.72.0 |
-| [hadolint](https://github.com/hadolint/hadolint) | 2.14.0 |
-| [act](https://github.com/nektos/act) | 0.2.89 |
-| [bats](https://github.com/bats-core/bats-core) | 1.13.0 |
-
-Renovate's native `mise` manager keeps `.mise.toml` up to date (automerge enabled).
+The pinned tool versions live in [`.mise.toml`](./.mise.toml) and are auto-installed by `make deps` via [mise](https://mise.jdx.dev) (mise itself is bootstrapped into `~/.local/bin` on first run). Renovate's native `mise` manager keeps them up to date (automerge enabled) — see `.mise.toml` for the exact pins.
 
 ## Architecture
 
@@ -522,7 +507,7 @@ First boot takes ~3–5 min (Ubuntu cloud image download, apt-get install, docke
 
 The cloud-init playbook (`vm/cloud-init.yaml`) runs once at first boot:
 
-1. Installs Docker CE, KinD v0.32.0, kubectl v1.36.3, helm v4.2.2
+1. Installs Docker CE, KinD, kubectl, and helm (versions pinned in [`vm/cloud-init.yaml`](./vm/cloud-init.yaml))
 2. Installs `nfs-kernel-server`, exports `/srv/k8s_nfs_storage`
 3. Clones this repo to `/home/ubuntu/kind-cluster`
 4. Writes `/var/lib/kind-cluster-bootstrapped` as the finished sentinel — `vm-up.sh` polls this file.

--- a/renovate.json
+++ b/renovate.json
@@ -68,18 +68,6 @@
       "matchStrings": [
         "plantuml-stdlib/C4-PlantUML/(?<currentValue>v\\d+\\.\\d+\\.\\d+)/"
       ]
-    },
-    {
-      "customType": "regex",
-      "description": "Track the kubectl version shown in prose in README.md — the Pinned-version table row (`| [kubectl](...) | 1.36.2 |`) and the cloud-init bootstrap prose (`... KinD v0.32.0, kubectl v1.36.2, ...`) — so the docs bump in lockstep with the functional pins instead of drifting on every patch. datasource=github-tags depName=kubernetes/kubernetes matches the Makefile/Dockerfile/cloud-init pins, so these land in the same 'kubectl' group and inherit the 3-day github-half minimumReleaseAge buffer. extractVersion strips the leading v from the github tags so both the bare table value and the `kubectl v...` prose capture/write bare digits (the literal `v` in the prose is outside the capture and stays). The prose matchString is anchored on the `KinD v..., kubectl v...` bootstrap shape (not a bare `kubectl vX.Y.Z`) so it can only match the install line, never a future version-compat note. NOTE: only kubectl is tracked here; the other README version-table rows (kind/jq/shellcheck/trivy/...) have the same latent drift but are a deliberate follow-up — a whole-table approach means many fragile prose regexes, and a whole-table *drift gate* would red every mise-tool bump PR until the README is regenerated, breaking mise automerge.",
-      "managerFilePatterns": ["/^README\\.md$/"],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "kubernetes/kubernetes",
-      "extractVersionTemplate": "^v(?<version>.*)$",
-      "matchStrings": [
-        "\\[kubectl\\]\\([^)]+\\)\\s*\\|\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*\\|",
-        "KinD v[\\d.]+, kubectl v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## What
Removes the README **"Pinned version" table** (10 tool versions) and the hardcoded versions in the cloud-init bootstrap line, replacing both with pointers to their source of truth (`.mise.toml` / `vm/cloud-init.yaml`). Also removes the now-dead kubectl-README `customManager` (added in #227).

## Why
Per @AndriyKalashnykov: the table just duplicated `.mise.toml`, so it drifted on every tool bump. Instead of tracking each row with Renovate (the approach in the now-closed #229), **eliminate the duplicate at the source** — the `/renovate` skill's preferred fix. `.mise.toml` is the single source of truth; Renovate's mise manager keeps it current.

## Result
- Zero hardcoded tool versions remain in `README.md`.
- No README-tracking `customManager` in `renovate.json` (drift is now impossible, not just tracked).
- The #226 buffer on the functional Makefile/Dockerfile/cloud-init kubectl/kind pins is unrelated and kept.

## Verification
- `renovate-config-validator`: OK (JSON still valid after removing the manager).
- `grep` confirms no `0.32.0`/`1.36.3`/`1.8.2`/… tool versions left in README.
- `grep -c README.md renovate.json` → 0.
