### PR TITLE
fix(istio): point charts at blob.istio.io — main red for 8 days

### DIFF
--- a/scripts/kind-add-gateway-istio.sh
+++ b/scripts/kind-add-gateway-istio.sh
@@ -17,22 +17,33 @@ KUBECTL=(kubectl --context="kind-${KIND_CLUSTER_NAME}")
 HELM=(helm --kube-context="kind-${KIND_CLUSTER_NAME}")
 TIMEOUT="${1:-5m}"
 
-# renovate: datasource=github-releases depName=istio/istio
+# Istio retired https://istio-release.storage.googleapis.com/charts: from 1.31 on,
+# charts are published ONLY to blob.istio.io, and the old bucket is deleted in
+# December 2026 (istio.io/latest/blog/2026/retirement-of-gcp/). Its index froze at
+# 2026-08-27, so base-1.31.0.tgz 404s there while it is HTTP 200 on blob.istio.io.
+# registryUrl MUST point at the live index or Renovate reads the frozen one, sees
+# 1.30.4 as newest, and silently never opens another PR.
+# Attribute order is load-bearing: datasource depName [extractVersion] [registryUrl].
+# renovate: datasource=helm depName=base registryUrl=https://blob.istio.io/istio-release/charts
 ISTIO_VERSION=1.31.0
-ISTIO_CHARTS="https://istio-release.storage.googleapis.com/charts"
+ISTIO_CHARTS="https://blob.istio.io/istio-release/charts"
 
-# Gateway API CRDs first — Istio ≤1.29 + v1.5 CRDs crash-loops istiod; this repo
-# pins Istio 1.30.x (supports Gateway API v1.5.x) so the order is the only gate.
+# Gateway API CRDs first — a too-old Istio against newer CRDs crash-loops istiod
+# (Istio ≤1.29 + v1.5 CRDs). Istio 1.31.0 vendors sigs.k8s.io/gateway-api v1.6.0
+# against this repo's v1.6.2 CRDs; keep this pin moving with the CRD channel.
 "$SCRIPT_DIR/kind-add-gateway-api-crds.sh"
 
 echo "=== Installing Istio ${ISTIO_VERSION} (base + istiod, minimal) ==="
-helm repo add istio "$ISTIO_CHARTS" >/dev/null 2>&1 || true
-helm repo update istio >/dev/null
-"${HELM[@]}" upgrade --install istio-base istio/base \
-    --version "${ISTIO_VERSION}" --namespace istio-system --create-namespace \
+# Direct chart tarball URLs — bypasses `helm repo add`+index.yaml, matching the
+# pattern kind-add-traefik.sh already uses, so an upstream index restructure cannot
+# break the install silently. It also sidesteps `helm repo add ... || true`, which
+# swallows the "repository name already exists" error a URL change raises and would
+# leave a developer's stale alias pointing at the retired bucket.
+"${HELM[@]}" upgrade --install istio-base "${ISTIO_CHARTS}/base-${ISTIO_VERSION}.tgz" \
+    --namespace istio-system --create-namespace \
     --wait --timeout "${TIMEOUT}"
-"${HELM[@]}" upgrade --install istiod istio/istiod \
-    --version "${ISTIO_VERSION}" --namespace istio-system \
+"${HELM[@]}" upgrade --install istiod "${ISTIO_CHARTS}/istiod-${ISTIO_VERSION}.tgz" \
+    --namespace istio-system \
     --wait --timeout "${TIMEOUT}"
 "${KUBECTL[@]}" -n istio-system rollout status deployment/istiod --timeout="${TIMEOUT}"
 

--- a/scripts/kind-add-gateway-kgateway.sh
+++ b/scripts/kind-add-gateway-kgateway.sh
@@ -24,7 +24,11 @@ KUBECTL=(kubectl --context="kind-${KIND_CLUSTER_NAME}")
 HELM=(helm --kube-context="kind-${KIND_CLUSTER_NAME}")
 TIMEOUT="${1:-5m}"
 
-# renovate: datasource=github-releases depName=kgateway-dev/kgateway
+# Tracked on the OCI chart repo (the CONSUMED sink), not the GitHub release:
+# a release can exist before/without its chart, which is exactly how the Istio
+# pin broke main. Upstream publishes both `v2.4.4` and `2.4.4` tag families;
+# the `v` form is what this pin uses.
+# renovate: datasource=docker depName=cr.kgateway.dev/kgateway-dev/charts/kgateway
 KGATEWAY_VERSION=v2.4.4
 KGATEWAY_CRDS_CHART="oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds"
 KGATEWAY_CHART="oci://cr.kgateway.dev/kgateway-dev/charts/kgateway"


### PR DESCRIPTION
fix(istio): point charts at blob.istio.io - main has been red for 8 days

gateway-test.yml has failed 7 consecutive runs on main since 2026-08-31,
always at the same step:

  Error: chart "base" matching 1.31.0 not found in istio index.
         no chart version found for base-1.31.0

Root cause is NOT that Istio 1.31.0 is unpublished. Istio RETIRED the
storage.googleapis.com chart bucket: from 1.31 onward charts are published
only to blob.istio.io, and the old locations are deleted in December 2026
(istio.io/latest/blog/2026/retirement-of-gcp/). That bucket's index froze on
2026-08-27, so it still serves 1.30.4 as newest and 404s base-1.31.0.

Measured:
  storage.googleapis.com/charts/base-1.31.0.tgz -> HTTP 404
  blob.istio.io/istio-release/charts/base-1.31.0.tgz -> HTTP 200

Three changes:

1. ISTIO_CHARTS moves to blob.istio.io. The version pin STAYS at 1.31.0 -
   reverting to 1.30.4 would be the riskier choice: 1.30.4 vendors
   sigs.k8s.io/gateway-api v1.5.1 while 1.31.0 vendors v1.6.0, against this
   repo's v1.6.2 CRDs. That version-skew gap is the same class that forced
   HAProxy Ingress out of the lab. 1.30.4 also still targets the retiring
   registry.istio.io images, while 1.31.0 uses docker.io/istio.

2. The Renovate annotation moves from datasource=github-releases to
   datasource=helm with registryUrl on the live index. The old annotation
   tracked the GitHub release while the value is consumed as a Helm chart
   version - a release can exist without its chart, which is exactly how
   this broke. Pointing registryUrl at the frozen bucket would be just as
   bad in the opposite direction: Renovate would read 1.30.4 as newest and
   silently never open another PR.

3. Both charts install from direct tarball URLs instead of helm repo add,
   matching the pattern kind-add-traefik.sh already documents. This also
   sidesteps "helm repo add ... || true", which swallows the "repository
   name already exists" error that a URL change raises, leaving a stale
   local alias pointed at the retired bucket.

kgateway carried the same datasource-vs-sink mismatch (github-releases
while consuming an OCI chart from cr.kgateway.dev) and is corrected to
datasource=docker. A survey of all 34 renovate annotations found these two
were the only mismatches; csi-driver-nfs, metallb, gateway-api and the
kubectl pins all correctly track their consumed sink.

Verified before pushing: both charts template from the new URLs (17 objects
each, istiod image docker.io/istio/pilot:1.31.0), shellcheck clean. The
cluster-level proof is a gateway-test.yml dispatch on this branch - the PR's
own ci-pass cannot cover it, since gateway-test.yml has no pull_request
trigger and the e2e job in ci.yml is tag-gated. That blind spot is why the
original bump merged green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012cSVWHsPrGu8m5Z68Gjbug
